### PR TITLE
Update Parse Docs

### DIFF
--- a/Documentation/DataIngress/OMF_Ingress_Publishers.md
+++ b/Documentation/DataIngress/OMF_Ingress_Publishers.md
@@ -236,25 +236,6 @@ A Publisher object.
 
 ******************************
 
-``POST api/tenants/{tenantId}/publishers``
----------------------------------------
-
-Creates or updates multiple publishers. Only the name and description of a publisher can be updated.
-
-**Parameters**
-
-``tenantId``
-  Unique Id for the tenant. 
-
-**Body**  
-An array of Publisher objects. 
-
-**Returns**
-
-An array of Publisher objects. 
-
-************************************
-
 ``POST api/tenants/{tenantId}/publishers/{publisherId}/tokens``
 --------------------------------------------
 
@@ -341,19 +322,5 @@ Deletes a token.
 **Returns**
 
 A Token object for the deleted token. 
-
-********************************
-
-``DELETE api/tenants/{tenantId}/publishers/{publisherId}/tokens``
----------------------------------------------------
-
-Deletes all tokens for a publisher.
-
-**Parameters**
-
-``tenantId`` 
-  Unique Id for the tenant. 
-``publisherId``
-  Unique Id for the publisher. 
 
 ********************************

--- a/Documentation/DataIngress/OMF_Ingress_Topics.md
+++ b/Documentation/DataIngress/OMF_Ingress_Topics.md
@@ -219,72 +219,6 @@ A MappedTopic object.
 
 ***********************
 
-``POST api/tenants/{tenantId}/namespaces/{namespaceId}/topics``
---------------------------------------------
-
-Creates or updates multiple topic. Only the topic name and description can be updated. 
-
-**Parameters**
-
-``tenantId``
-  Unique Id for the tenant. 
-``namespaceId``
-  Unique Id for the namespace. 
-
-**Body**
-
-An array of MappedTopic objects. 
-
-**Returns**
-
-An array of MappedTopic objects. 
-
-**********************
-
-``POST api/tenants/{tenantId}/namespaces/{namespaceId}/publishertopicmapping``
----------------------------------------------------------
-
-Creates a mapping between a publisher and topic. 
-
-**Parameters**
-
-``tenantId``
-  Unique Id for the tenant. 
-``namespaceId``
-  Unique Id for the namespace. 
-
-**Body**
-
-A MappedPublisher object. 
-
-**Returns**
-
-A MappedPublisher object. 
-
-**********************
-
-``POST api/tenants/{tenantId}/namespaces/{namespaceId}/publishertopicmappings``
-----------------------------------------------------------
-
-Creates multiple mappings between publishers and topics 
-
-**Parameters**
-
-``tenantId``
-  Unique Id for the tenant. 
-``namespaceId``
-  Unique Id for the namespace. 
-
-**Body**
-
-An array of MappedPublisher objects. 
-
-**Returns** 
-
-An array of MappedPublisher objects. 
-
-************************
-
 ``PUT api/tenants/{tenantId}/namespaces/{namespaceId}/accesscontrol/topics``
 ----------------------------------------------------------
 
@@ -322,26 +256,6 @@ Update the Access Control List for a particular topic
 An AccessControlList object.
 
 ************************
-``DELETE api/tenants/{tenantId}/namespaces/{namespaceId}/publishertopicmappings/{topicId}``
-------------------------------------------------------------------------------
-
-Delete mappings between a topic and multiple publishers. 
-
-**Parameters**
-
-``tenantId``
-  Unique Id for the tenant. 
-``namespaceId``
-  Unique Id for the namespace. 
-``topicId``
-  Unique Id for the topic. 
-
-**Body**
-
-A string array of Publisher Ids to remove from the Topic. 
-
-
-**************************
 
 ``DELETE api/tenants/{tenantId}/namespaces/{namespaceId}/topics/{topicId}``
 ----------------------------------------------------------------


### PR DESCRIPTION
Due to code cleanups and an ongoing effort to adhere to better adhere to REST API guidelines, Parse has removed the following routes:

- POST api/tenants/{tenantId}/publishers
- DELETE api/tenants/{tenantId}/publishers/{publisherId}/tokens
- POST api/tenants/{tenantId}/namespaces/{namespaceId}/topics
- POST api/tenants/{tenantId}/namespaces/{namespaceId}/publishertopicmapping
- POST api/tenants/{tenantId}/namespaces/{namespaceId}/publishertopicmappings
- DELETE api/tenants/{tenantId}/namespaces/{namespaceId}/publishertopicmappings/{topicId}