### PR TITLE
Update OMF Ingress page

### DIFF
--- a/Documentation/DataIngress/OMF_Ingress_Specification.md
+++ b/Documentation/DataIngress/OMF_Ingress_Specification.md
@@ -87,7 +87,7 @@ A Container message is interpreted as a SdsStream in the OCS Data Store. The key
 in the Container definition are interpreted as follows:
 
 * ``id``: Corresponds to the SdsStream Id field. It must conform to the rules defined for
-    an SdsStream.Id specified here : [Streams](xref:sdsStreams#streams).
+    an SdsStream Id specified here: [Streams](xref:sdsStreams#streams).
 * ``typeid``: Corresponds to the SdsStream TypeId field.
 * ``typeversion``: Versioning of SdsTypes is not supported.
 * ``name``: Corresponds to the SdsStream Name field. This is a friendly name for the stream.

--- a/Documentation/DataIngress/OMF_Ingress_Specification.md
+++ b/Documentation/DataIngress/OMF_Ingress_Specification.md
@@ -62,7 +62,7 @@ OMF message types fall into three categories: Type, Container, and Data, which a
   types (see [Types](xref:sdsTypes))
 
 
-Type     | Format   | QiTypeCode
+Type     | Format   | SdsTypeCode
 -------- | -------- | -----------
 array		 |          | IEnumerable
 boolean  |          | boolean

--- a/Documentation/DataIngress/OMF_Ingress_Specification.md
+++ b/Documentation/DataIngress/OMF_Ingress_Specification.md
@@ -18,7 +18,7 @@ set to a security token obtained from the OCS Portal. The security token is used
 the sender and to authorize the sender for use with a particular Tenant and Publisher.
 
 The ``omfversion`` header must match the version of the OMF spec used to construct the message.
-Version 1.0 of the spec is currently supported. 
+Version 1.1 of the spec is currently supported. 
 
 Message Types
 -------------

--- a/Documentation/DataIngress/toc.yml
+++ b/Documentation/DataIngress/toc.yml
@@ -1,7 +1,5 @@
 - name: Data Ingress to Cloud Services Using OMF
   href: OMF_Ingress_to_OCS.md
-- name: Quick start
-  href: ../SequentialDataStore/Quick_Start.md
 - name: Using OMF with Cloud Services
   href: OMF_Ingress_Specification.md
 - name: Publishers

--- a/Documentation/SequentialDataStore/Filter_Expressions.md
+++ b/Documentation/SequentialDataStore/Filter_Expressions.md
@@ -11,7 +11,7 @@ Filter expressions can be applied to any read that returns multiple values, incl
 ``Get Values``, ``Get Range Values``, ``Get Window Values``, and ``Get Intervals``.”
 
 
-QiTypeCodes
+SdsTypeCodes
 ------------
 
 **Supported**

--- a/index.md
+++ b/index.md
@@ -49,7 +49,6 @@ easily obtain needed information.
      - [Table Format](xref:sdsTableFormat)
    - [Data Ingress and OSIsoft Message Format](xref:dataIngress)
      - [Data Ingress to Cloud Services Using OMF](xref:omfIngressToOCS)
-     - [Quick Start](xref:sdsQuickStart)
      - [Using OMF with Cloud Services](xref:omfIngressSpecification)
      - [Publishers](xref:omfIngressPublishers)
      - [Topics](xref:omfIngressTopics)


### PR DESCRIPTION
I removed the Quick Start section in OMF Ingress. It only pointed to the quick start section for SDS and caused errors when selecting that link in the page.

Other changes were just minor clean up:

- Changed supported OMF version to 1.1
- Fixed a couple of references to QiTypeCode 