### PR TITLE
Enable DocFX full-text search

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -15,6 +15,9 @@
     }
   ],
   "build": {
+	"globalMetadata": {
+		"_enableSearch": true
+	},
     "content": [
       {
         "files": [


### PR DESCRIPTION
Adding the _enableSearch setting so that we can take advantage of the OOTB full-text search feature in DocFX.  The index will be automatically generated in the _site folder with each build.