### PR TITLE
Fixed access control links

### DIFF
--- a/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Documentation/SequentialDataStore/SDS_Streams.md
@@ -430,7 +430,7 @@ The response includes a status code.
 
 ## `Get Streams Access Control List`
 
-Get the default ACL for the Streams collection. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the default ACL for the Streams collection. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -459,7 +459,7 @@ The default ACL for Streams
 
 ## `Update Streams Access Control List`
 
-Update the default ACL for the Streams collection. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the default ACL for the Streams collection. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -489,7 +489,7 @@ The response includes a status code.
 
 ## `Get Stream Access Control List`
 
-Get the ACL of the specified stream. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the ACL of the specified stream. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -521,7 +521,7 @@ The ACL for the specified stream
 
 ## `Update Stream Access Control List`
 
-Update the ACL of the specified stream. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the ACL of the specified stream. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -553,7 +553,7 @@ The response includes a status code.
 
 ## `Get Stream Owner`
 
-Get the Owner of the specified stream. For more information on Owners, see [Access Control](xref:accesscontrol).
+Get the Owner of the specified stream. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -585,7 +585,7 @@ The Owner for the specified stream
 
 ## `Update Stream Owner`
 
-Update the Owner of the specified stream. For more information on Owners, see [Access Control](xref:accesscontrol).
+Update the Owner of the specified stream. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text

--- a/Documentation/SequentialDataStore/SDS_Types.md
+++ b/Documentation/SequentialDataStore/SDS_Types.md
@@ -1427,7 +1427,7 @@ The response includes a status code.
 
 ## `Get Types Access Control List`
 
-Get the default ACL for the Types collection. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the default ACL for the Types collection. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -1456,7 +1456,7 @@ The default ACL for Types
 
 ## `Update Types Access Control List`
 
-Update the default ACL for the Types collection. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the default ACL for the Types collection. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -1486,7 +1486,7 @@ The response includes a status code.
 
 ## `Get Type Access Control List`
 
-Get the ACL of the specified type. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the ACL of the specified type. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -1518,7 +1518,7 @@ The ACL for the specified type
 
 ## `Update Type Access Control List`
 
-Update the ACL of the specified type. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the ACL of the specified type. For more information on ACLs, see [Access Control](xref:accessControl).
 
 Note that this does not update the ACL for the associated types. For further details about type referencing please see: [Type Reusability](#type-reusability).
 
@@ -1552,7 +1552,7 @@ The response includes a status code.
 
 ## `Get Type Owner`
 
-Get the Owner of the specified type. For more information on Owners, see [Access Control](xref:accesscontrol).
+Get the Owner of the specified type. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -1584,7 +1584,7 @@ The Owner for the specified type
 
 ## `Update Type Owner`
 
-Update the Owner of the specified type. For more information on Owners, see [Access Control](xref:accesscontrol).
+Update the Owner of the specified type. For more information on Owners, see [Access Control](xref:accessControl).
 
 Note that this does not update the Owner for the associated types. For further details about type referencing please see: [Type Reusability](#type-reusability).
 

--- a/Documentation/SequentialDataStore/SDS_Views.md
+++ b/Documentation/SequentialDataStore/SDS_Views.md
@@ -768,7 +768,7 @@ The response includes a status code.
 ***********************
 ## `Get Stream Views Access Control List`
 
-Get the default ACL for the Stream Views collection. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the default ACL for the Stream Views collection. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -797,7 +797,7 @@ The default ACL for Stream Views
 
 ## `Update Stream Views Access Control List`
 
-Update the default ACL for the Stream Views collection. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the default ACL for the Stream Views collection. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -827,7 +827,7 @@ The response includes a status code.
 
 ## `Get Stream View Access Control List`
 
-Get the ACL of the specified stream view. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the ACL of the specified stream view. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -859,7 +859,7 @@ The ACL for the specified stream view
 
 ## `Update Stream View Access Control List`
 
-Update the ACL of the specified stream view. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the ACL of the specified stream view. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -891,7 +891,7 @@ The response includes a status code.
 
 ## `Get Stream View Owner`
 
-Get the Owner of the specified stream view. For more information on Owners, see [Access Control](xref:accesscontrol).
+Get the Owner of the specified stream view. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -923,7 +923,7 @@ The Owner for the specified stream view
 
 ## `Update Stream View Owner`
 
-Update the Owner of the specified stream view. For more information on Owners, see [Access Control](xref:accesscontrol).
+Update the Owner of the specified stream view. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text

--- a/Documentation/SequentialDataStore/Units_of_Measure.md
+++ b/Documentation/SequentialDataStore/Units_of_Measure.md
@@ -538,7 +538,7 @@ Content-Type: application/json
 
 ## `Get Quantities Access Control List`
 
-Get the default ACL for the Quantities collection. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the default ACL for the Quantities collection. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -567,7 +567,7 @@ The default ACL for Quantities
 
 ## `Update Quantities Access Control List`
 
-Update the default ACL for the Quantities collection. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the default ACL for the Quantities collection. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -597,7 +597,7 @@ The response includes a status code.
 
 ## `Get Quantity Access Control List`
 
-Get the ACL of the specified quantity. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the ACL of the specified quantity. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -629,7 +629,7 @@ The ACL for the specified quantity
 
 ## `Update Quantity Access Control List`
 
-Update the ACL of the specified quantity. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the ACL of the specified quantity. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -661,7 +661,7 @@ The response includes a status code.
 
 ## `Get Quantity Owner`
 
-Get the Owner of the specified quantity. For more information on Owners, see [Access Control](xref:accesscontrol).
+Get the Owner of the specified quantity. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -693,7 +693,7 @@ The Owner for the specified quantity
 
 ## `Update Quantity Owner`
 
-Update the Owner of the specified quantity. For more information on Owners, see [Access Control](xref:accesscontrol).
+Update the Owner of the specified quantity. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -840,7 +840,7 @@ Content-Type: application/json
 
 ## `Get Uom Access Control List`
 
-Get the ACL of the specified unit of measure. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Get the ACL of the specified unit of measure. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -875,7 +875,7 @@ The ACL for the specified Uom
 
 ## `Update Uom Access Control List`
 
-Update the ACL of the specified unit of measure. For more information on ACLs, see [Access Control](xref:accesscontrol).
+Update the ACL of the specified unit of measure. For more information on ACLs, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -910,7 +910,7 @@ The response includes a status code.
 
 ## `Get Uom Owner`
 
-Get the Owner of the specified unit of measure. For more information on Owners, see [Access Control](xref:accesscontrol).
+Get the Owner of the specified unit of measure. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text
@@ -945,7 +945,7 @@ The Owner for the specified Uom
 
 ## `Update Uom Owner`
 
-Update the Owner of the specified unit of measure. For more information on Owners, see [Access Control](xref:accesscontrol).
+Update the Owner of the specified unit of measure. For more information on Owners, see [Access Control](xref:accessControl).
 
 **Request**
  ```text


### PR DESCRIPTION
Fixed the access control links in the documentation for Types, Streams, Stream Views, and Units of Measure