### PR TITLE
Correcting cut off content in sidebar

### DIFF
--- a/_exported_templates/default/styles/docfx.css
+++ b/_exported_templates/default/styles/docfx.css
@@ -596,7 +596,8 @@ body .toc{
   margin-top: 50px;
   font-size: 12px;
   max-height: 100%;
-  overflow: hidden;
+  max-width: 20%;
+  overflow-wrap: break-word;
   top: 100px;
   bottom: 10px;
   position: fixed;


### PR DESCRIPTION
To make some previously hidden content visible, this CSS change sets a reasonable maximum width for the side affixed content and allows it to wrap if content is too long.