### PR TITLE
Changing i.e. to e.g.

### DIFF
--- a/Documentation/SequentialDataStore/Units_of_Measure.md
+++ b/Documentation/SequentialDataStore/Units_of_Measure.md
@@ -6,7 +6,7 @@ uid: unitsOfMeasure
 
 The Sequential Data Store (SDS) provides a collection of built-in units of measure (Uom). These units of measure can be [associated](#associating-a-unit-of-measure-with-a-sdstype) with SdsStreams and SdsTypes in order to provide unit information for stream data that model measurable quantities. If data has unit information associated with it, SDS is able to support unit conversions when retrieving data. See [Reading data](xref:sdsReadingData) for more information.
 
-Since a unit of measurement (i.e. meter) defines the magnitude of a quantity (i.e. Length), SDS represents this via two objects: SdsUom and SdsUomQuantity. 
+Since a unit of measurement (e.g. meter) defines the magnitude of a quantity (e.g. Length), SDS represents this via two objects: SdsUom and SdsUomQuantity. 
 
 ## SdsUom
 
@@ -26,7 +26,7 @@ The following table shows the required and optional SdsUom fields.
 
 ## SdsUomQuantity
 
-Represents a single measurable quantity (i.e. Length)
+Represents a single measurable quantity (e.g. Length)
 
 The following table shows the required and optional SdsUomQuantity fields.
 


### PR DESCRIPTION
I.e. means "in other words", usually if you want to tell someone a more commonly used synonym to a word that they may not be familiar with.  E.g. means "for example", which seems more appropriate in the context of how "i.e." is being used here.  Meter is not a synonym for "unit of measure", it's an example of a unit.

Fixes #155 