### PR TITLE
Spelling out e.g. to "for example"

### DIFF
--- a/Documentation/SequentialDataStore/Units_of_Measure.md
+++ b/Documentation/SequentialDataStore/Units_of_Measure.md
@@ -4,9 +4,9 @@ uid: unitsOfMeasure
 
 # Units of Measure
 
-The Sequential Data Store (SDS) provides a collection of built-in units of measure (Uom). These units of measure can be [associated](#associating-a-unit-of-measure-with-a-sdstype) with SdsStreams and SdsTypes in order to provide unit information for stream data that model measurable quantities. If data has unit information associated with it, SDS is able to support unit conversions when retrieving data. See [Reading data](xref:sdsReadingData) for more information.
+The Sequential Data Store (SDS) provides a collection of built-in units of measure (UOM). These units of measure can be [associated](#associating-a-unit-of-measure-with-a-sdstype) with SdsStreams and SdsTypes in order to provide unit information for stream data that model measurable quantities. If data has unit information associated with it, SDS is able to support unit conversions when retrieving data. See [Reading data](xref:sdsReadingData) for more information.
 
-Since a unit of measurement (e.g. meter) defines the magnitude of a quantity (e.g. Length), SDS represents this via two objects: SdsUom and SdsUomQuantity. 
+Since a unit of measure (meter, for example) defines the magnitude of a quantity (for example, length), SDS represents this by way of two objects: SdsUom and SdsUomQuantity. 
 
 ## SdsUom
 
@@ -26,7 +26,7 @@ The following table shows the required and optional SdsUom fields.
 
 ## SdsUomQuantity
 
-Represents a single measurable quantity (e.g. Length)
+Represents a single measurable quantity (for example, length)
 
 The following table shows the required and optional SdsUomQuantity fields.
 


### PR DESCRIPTION
The use of exempli gratia (e.g.) is accurate but a plain English may be easier for a broader audience.