### PR TITLE
Changed 2020 in the footer to $COPYRIGHT_YEAR

### DIFF
--- a/_exported_templates/default/partials/footer.tmpl.partial
+++ b/_exported_templates/default/partials/footer.tmpl.partial
@@ -3,6 +3,6 @@
 <footer>
   <div class="grad-bottom"></div>
   <div class="footer">
-      <span id='copyright-text'>© 2020 - OSIsoft, LLC.<span>
+      <span id='copyright-text'>© $COPYRIGHT_YEAR - OSIsoft, LLC.<span>
   </div>
 </footer>


### PR DESCRIPTION
 so that it automatically updates with the latest year that the documentation was updated.