### PR TITLE
Updating links to the code samples

### DIFF
--- a/Documentation/samples.md
+++ b/Documentation/samples.md
@@ -18,9 +18,9 @@ The examples cover the basics of interacting with OCS, such as:
 Currently, the samples are available in these languages:
 
 * [.NET](https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/DotNet) 
-* [Java](https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Java/sdsjava)
-* [Python](https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Python/SDSPy/Python3)
-* [NodeJs](https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/JavaScript/NodeJs)
+* [Java](https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Java)
+* [Python](https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Python)
+* [NodeJs](https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/JavaScript/NodeJS)
 * [Angular](https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/JavaScript/Angular)
 
 Because the examples are intended for demonstration purposes, they represent some example


### PR DESCRIPTION
Updating links to java, python, and nodeJs as examples are not working on the samples page.