### PR TITLE
Change description of the "count" query param in GetData

### DIFF
--- a/Content_Portal/Documentation/DataViews/Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Data_API.md
@@ -47,7 +47,7 @@ Controls when the data view backing resources are to be refreshed. Used only whe
 | `Preserve`| Use cached information, if available.   
 
 `[optional] int count`  
-The requested page size. The default value is 1000. The maximum is 250,000.
+The requested page size. The default is calculated as 100,000 / # columns. The maximum is 250,000.
 
 ### Response
 The response includes a status code and, in most cases, a body.

--- a/Content_Portal/Documentation/DataViews/Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Data_API.md
@@ -47,7 +47,7 @@ Controls when the data view backing resources are to be refreshed. Used only whe
 | `Preserve`| Use cached information, if available.   
 
 `[optional] int count`  
-The requested page size. The maximum is 250,000. If the parameter is not provided, [a default page size will be calculated](xref:DataViewsGettingData#page-size).
+The requested page size. The maximum is 250,000. If the parameter is not provided, [an optimal page size will be calculated](xref:DataViewsGettingData#page-size).
 
 ### Response
 The response includes a status code and, in most cases, a body.

--- a/Content_Portal/Documentation/DataViews/Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Data_API.md
@@ -47,7 +47,7 @@ Controls when the data view backing resources are to be refreshed. Used only whe
 | `Preserve`| Use cached information, if available.   
 
 `[optional] int count`  
-The requested page size. The default is calculated as 100,000 / # columns. The maximum is 250,000.
+The requested page size. The maximum is 250,000. The default number of cells per page is 100,000, so the default page size is calculated as 100,000  divided by the number of columns.
 
 ### Response
 The response includes a status code and, in most cases, a body.

--- a/Content_Portal/Documentation/DataViews/Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Data_API.md
@@ -47,7 +47,7 @@ Controls when the data view backing resources are to be refreshed. Used only whe
 | `Preserve`| Use cached information, if available.   
 
 `[optional] int count`  
-The requested page size. The maximum is 250,000. The default number of cells per page is 100,000 so the default page size is calculated as 100,000 divided by the number of columns.
+The requested page size. The maximum is 250,000. If the parameter is not provided, [a default page size will be calculated](xref:DataViewsGettingData#page-size).
 
 ### Response
 The response includes a status code and, in most cases, a body.

--- a/Content_Portal/Documentation/DataViews/Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Data_API.md
@@ -47,7 +47,7 @@ Controls when the data view backing resources are to be refreshed. Used only whe
 | `Preserve`| Use cached information, if available.   
 
 `[optional] int count`  
-The requested page size. The maximum is 250,000. The default number of cells per page is 100,000, so the default page size is calculated as 100,000  divided by the number of columns.
+The requested page size. The maximum is 250,000. The default number of cells per page is 100,000 so the default page size is calculated as 100,000 divided by the number of columns.
 
 ### Response
 The response includes a status code and, in most cases, a body.

--- a/Content_Portal/Documentation/DataViews/Getting_Data.md
+++ b/Content_Portal/Documentation/DataViews/Getting_Data.md
@@ -72,7 +72,7 @@ The view data is available in several formats.
 Data retrieval operations are paged. Data for a requested index range may span multiple pages.
 
 ### Page size
-By default, each page includes 1000 records. The maximum page size is 250,000. 
+The maximum page size is 250,000. If `count` query parameter is not provided, the page size is going to be calculated as 100,000 divided by the number of columns, where 100,000 is the default cell count per data request. Users can see the calculated page size in the first and next page links in the `Link` response header (described below).
 
 Optimal page size is dependent both on the client and on the shape of the data view. The size of each individual record is proportional to the "width" of the data view, i.e. how many field mappings are resolved. Clients retrieving data views that resolve into few field mappings may wish to use a page size close to the maximum.
 

--- a/Content_Portal/Documentation/DataViews/Getting_Data.md
+++ b/Content_Portal/Documentation/DataViews/Getting_Data.md
@@ -76,7 +76,7 @@ The maximum page size is 250,000.
 
 Optimal page size is dependent both on the client and on the shape of the data view. The size of each individual record is proportional to the "width" of the data view, i.e. how many field mappings are resolved. Clients retrieving data views that resolve into few field mappings may wish to use a page size close to the maximum.
 
-If `count` query parameter is not provided, the page size will be calculated as 100,000 divided by the number of field mappings, where 100,000 is a number representing the default product of the number of field mappings and the page size. Users can see the calculated page size as a `count` query parameter in the `Link` response header (described below). The calculated count will be included in both the first and the next page links. 
+If `count` query parameter is not provided, the page size will be calculated as 100,000 divided by the number of field mappings, where 100,000 is used as the default product of the number of field mappings and the page size. Users can see the calculated page size as a `count` query parameter in the `Link` response header (described below). The calculated page size will be included in both the first and the next page links. 
 
 ### Hyperlinks
 When paging through data view data via the REST API, hyperlinks to the first page and next page of data are provided in the `Link` header. The first page header is signified by relation type of first, `rel="first"`. The next page header is signified by `rel="next"`. Proper use of the hyperlinks is recommended.

--- a/Content_Portal/Documentation/DataViews/Getting_Data.md
+++ b/Content_Portal/Documentation/DataViews/Getting_Data.md
@@ -72,9 +72,11 @@ The view data is available in several formats.
 Data retrieval operations are paged. Data for a requested index range may span multiple pages.
 
 ### Page size
-The maximum page size is 250,000. If `count` query parameter is not provided, the page size is going to be calculated as 100,000 divided by the number of columns, where 100,000 is the default cell count per data request. Users can see the calculated page size in the first and next page links in the `Link` response header (described below).
+The maximum page size is 250,000.
 
 Optimal page size is dependent both on the client and on the shape of the data view. The size of each individual record is proportional to the "width" of the data view, i.e. how many field mappings are resolved. Clients retrieving data views that resolve into few field mappings may wish to use a page size close to the maximum.
+
+If `count` query parameter is not provided, the page size will be calculated as 100,000 divided by the number of field mappings, where 100,000 is a number representing the default product of the number of field mappings and the page size. Users can see the calculated page size as a `count` query parameter in the `Link` response header (described below). The calculated count will be included in both the first and the next page links. 
 
 ### Hyperlinks
 When paging through data view data via the REST API, hyperlinks to the first page and next page of data are provided in the `Link` header. The first page header is signified by relation type of first, `rel="first"`. The next page header is signified by `rel="next"`. Proper use of the hyperlinks is recommended.

--- a/Content_Portal/Documentation/DataViews/Getting_Data.md
+++ b/Content_Portal/Documentation/DataViews/Getting_Data.md
@@ -72,11 +72,11 @@ The view data is available in several formats.
 Data retrieval operations are paged. Data for a requested index range may span multiple pages.
 
 ### Page size
-The maximum page size is 250,000.
-
 Optimal page size is dependent both on the client and on the shape of the data view. The size of each individual record is proportional to the "width" of the data view, i.e. how many field mappings are resolved. Clients retrieving data views that resolve into few field mappings may wish to use a page size close to the maximum.
 
-If `count` query parameter is not provided, the page size will be calculated as 100,000 divided by the number of field mappings, where 100,000 is used as the default product of the number of field mappings and the page size. Users can see the calculated page size as a `count` query parameter in the `Link` response header (described below). The calculated page size will be included in both the first and the next page links. 
+By default, data views will be returned with an optimized page size based on the size and layout of the data view. Users can see the calculated page size as a `count` query parameter in the `Link` response header (described below). The calculated page size will be included in both the first and the next page links. This default page size can be overridden, however, by providing a `count` query parameter.
+
+The maximum page size is 250,000.
 
 ### Hyperlinks
 When paging through data view data via the REST API, hyperlinks to the first page and next page of data are provided in the `Link` header. The first page header is signified by relation type of first, `rel="first"`. The next page header is signified by `rel="next"`. Proper use of the hyperlinks is recommended.

--- a/Content_Portal/Documentation/DataViews/Preview_Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Preview_Data_API.md
@@ -42,7 +42,7 @@ The requested data [output format](xref:DataViewsGettingData#format). Output for
 Used only when [paging](xref:DataViewsGettingData#paging). Not specified when requesting the first page of data.
 
 `[optional] int count`  
-The requested page size. The default value is 1000. The maximum is 250,000.
+The requested page size. The default is calculated as 100,000 / # columns. The maximum is 250,000.
 
 #### Example request body
 ```json

--- a/Content_Portal/Documentation/DataViews/Preview_Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Preview_Data_API.md
@@ -42,7 +42,7 @@ The requested data [output format](xref:DataViewsGettingData#format). Output for
 Used only when [paging](xref:DataViewsGettingData#paging). Not specified when requesting the first page of data.
 
 `[optional] int count`  
-The requested page size. The default is calculated as 100,000 / # columns. The maximum is 250,000.
+The requested page size. The maximum is 250,000. The default number of cells per page is 100,000 so the default page size is calculated as 100,000 divided by the number of columns.
 
 #### Example request body
 ```json

--- a/Content_Portal/Documentation/DataViews/Preview_Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Preview_Data_API.md
@@ -42,7 +42,8 @@ The requested data [output format](xref:DataViewsGettingData#format). Output for
 Used only when [paging](xref:DataViewsGettingData#paging). Not specified when requesting the first page of data.
 
 `[optional] int count`  
-The requested page size. The maximum is 250,000. The default number of cells per page is 100,000 so the default page size is calculated as 100,000 divided by the number of columns.
+The requested page size. The maximum is 250,000. If the parameter is not provided, [a default page size will be calculated](xref:DataViewsGettingData#page-size).
+
 
 #### Example request body
 ```json

--- a/Content_Portal/Documentation/DataViews/Preview_Data_API.md
+++ b/Content_Portal/Documentation/DataViews/Preview_Data_API.md
@@ -42,7 +42,7 @@ The requested data [output format](xref:DataViewsGettingData#format). Output for
 Used only when [paging](xref:DataViewsGettingData#paging). Not specified when requesting the first page of data.
 
 `[optional] int count`  
-The requested page size. The maximum is 250,000. If the parameter is not provided, [a default page size will be calculated](xref:DataViewsGettingData#page-size).
+The requested page size. The maximum is 250,000. If the parameter is not provided, [an optimal page size will be calculated](xref:DataViewsGettingData#page-size).
 
 
 #### Example request body


### PR DESCRIPTION
We now calculate default page size instead of hard-coding it as 1,000.

The PR reflects this changes in the description of the query parameter "count" for both preview and non-preview GetData endpoints.