### PR TITLE
Adding a line on how compound indexing of the primary index affects secondary indexes

### DIFF
--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -48,7 +48,7 @@ Secondary indexes are defined on the SdsStream while the primary index is define
 If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than 2 properties. For more information on compound indexes, see [Indexes](xref:sdsIndexes#compound-indexes). 
 <!-- Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.-->
   
-Note that you can only use the SdsTypeCodes that can be ordered (DateTime or numbers, for example) as a secondary index.
+Note that you can only use the SdsTypeCodes of SdsTypes whose property can be ordered (DateTime or numbers, for example) as a secondary index.
 
 ## Interpolation and extrapolation
 The InterpolationMode, ExtrapolationMode, and [PropertyOverrides](#propertyoverrides) can be used to determine how a specific SdsStream reads data.

--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -44,7 +44,7 @@ However, they are associated with SdsStream objects and can be used as search cr
 5. Can contain a maximum of 100 characters
 
 ## Indexes
-You define secondary indexes on the SdsStream and primary index on the SdsType.
+You define secondary indexes on the SdsStream and the primary index on the SdsType.
 If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than two properties. For more information on compound indexes, see [Indexes](xref:sdsIndexes#compound-indexes). 
 <!-- Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.-->
   

--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -45,7 +45,8 @@ However, they are associated with SdsStream objects and can be used as search cr
 
 ## Indexes
 While the primary index is defined at the SdsType, secondary
-indexes are defined at the SdsStream.
+indexes are defined at the SdsStream. If the primary index is a compound index,
+secondary indexes will only be valid if the compound index has a maximum of 2 properties.
 
 Secondary indexes are applied to a single property; there are no
 compound secondary indexes. Only SdsTypeCodes

--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -48,7 +48,7 @@ You define secondary indexes on the SdsStream and the primary index on the SdsTy
 If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than two properties. For more information on compound indexes, see [Indexes](xref:sdsIndexes#compound-indexes). 
 <!-- Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.-->
   
-Note that you can only use the SdsTypeCodes of SdsType properties that can be ordered (DateTime or numbers, for example) as a secondary index.
+Note that you can only use the SdsTypeCodes of SdsType properties that can be ordered (``DateTime`` or numbers, for example) as a secondary index.
 
 ## Interpolation and extrapolation
 The InterpolationMode, ExtrapolationMode, and [PropertyOverrides](#propertyoverrides) can be used to determine how a specific SdsStream reads data.

--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -45,8 +45,7 @@ However, they are associated with SdsStream objects and can be used as search cr
 
 ## Indexes
 Secondary indexes are defined on the SdsStream while the primary index is defined on the SdsType.
-Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.
-Secondary index is allowed as long as the primary index that is a compound index has up to 2 properties.   
+If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than 2 properties. Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.
   
 Note that only the SdsTypeCodes that can be ordered are supported for use in a secondary index.
 For more information, see [Indexes](xref:sdsIndexes).

--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -44,7 +44,7 @@ However, they are associated with SdsStream objects and can be used as search cr
 5. Can contain a maximum of 100 characters
 
 ## Indexes
-You define secondary indexes on the SdsStream and the primary index on the SdsType.
+While you define the primary index on the SdsType, the SdsStream is where you define secondary indexes.
 If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than two properties. For more information on compound indexes, see [Indexes](xref:sdsIndexes#compound-indexes). 
 <!-- Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.-->
   

--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -44,15 +44,12 @@ However, they are associated with SdsStream objects and can be used as search cr
 5. Can contain a maximum of 100 characters
 
 ## Indexes
-While the primary index is defined at the SdsType, secondary
-indexes are defined at the SdsStream. If the primary index is a compound index,
-secondary indexes will only be valid if the compound index has a maximum of 2 properties.
-
-Secondary indexes are applied to a single property; there are no
-compound secondary indexes. Only SdsTypeCodes
-that can be ordered are supported for use in a secondary index.
-
-For more information on indexes, see [Indexes](xref:sdsIndexes).
+Secondary indexes are defined on the SdsStream while the primary index is defined on the SdsType.
+Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.
+Secondary index is allowed as long as the primary index that is a compound index has up to 2 properties.   
+  
+Note that only the SdsTypeCodes that can be ordered are supported for use in a secondary index.
+For more information, see [Indexes](xref:sdsIndexes).
 
 ## Interpolation and extrapolation
 The InterpolationMode, ExtrapolationMode, and [PropertyOverrides](#propertyoverrides) can be used to determine how a specific SdsStream reads data.

--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -45,10 +45,10 @@ However, they are associated with SdsStream objects and can be used as search cr
 
 ## Indexes
 Secondary indexes are defined on the SdsStream while the primary index is defined on the SdsType.
-If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than 2 properties. Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.
+If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than 2 properties. For more information on compound indexes, see [Indexes](xref:sdsIndexes#compound-indexes). 
+<!-- Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.-->
   
-Note that only the SdsTypeCodes that can be ordered are supported for use in a secondary index.
-For more information, see [Indexes](xref:sdsIndexes).
+Note that you can only use the SdsTypeCodes that can be ordered (DateTime or numbers, for example) as a secondary index.
 
 ## Interpolation and extrapolation
 The InterpolationMode, ExtrapolationMode, and [PropertyOverrides](#propertyoverrides) can be used to determine how a specific SdsStream reads data.

--- a/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
+++ b/Content_Portal/Documentation/SequentialDataStore/SDS_Streams.md
@@ -44,11 +44,11 @@ However, they are associated with SdsStream objects and can be used as search cr
 5. Can contain a maximum of 100 characters
 
 ## Indexes
-Secondary indexes are defined on the SdsStream while the primary index is defined on the SdsType.
-If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than 2 properties. For more information on compound indexes, see [Indexes](xref:sdsIndexes#compound-indexes). 
+You define secondary indexes on the SdsStream and primary index on the SdsType.
+If the primary index defined on the SdsType is a compound index, secondary indexes on the SdsStream are allowed as long as that compound index does not have more than two properties. For more information on compound indexes, see [Indexes](xref:sdsIndexes#compound-indexes). 
 <!-- Secondary indexes apply to a single property. In other words, there are no compound secondary indexes.-->
   
-Note that you can only use the SdsTypeCodes of SdsTypes whose property can be ordered (DateTime or numbers, for example) as a secondary index.
+Note that you can only use the SdsTypeCodes of SdsType properties that can be ordered (DateTime or numbers, for example) as a secondary index.
 
 ## Interpolation and extrapolation
 The InterpolationMode, ExtrapolationMode, and [PropertyOverrides](#propertyoverrides) can be used to determine how a specific SdsStream reads data.

--- a/Content_Portal/Documentation/SequentialDataStore/indexes.md
+++ b/Content_Portal/Documentation/SequentialDataStore/indexes.md
@@ -64,7 +64,7 @@ In read and write operations, specify compound indexes in the URI by ordering ea
 To help those using compound indexes, .NET client libraries methods also allow the use of tuples for indexes.
 
 **Notes:** 
-- Compound indexing only applies to SdsTypes. In other words, there is no compound indexing for secondary indexes which are on SdsStreams. For more information see [SdsStreams](xref:sdsStreams#indexes).  
+- Compound indexing only applies to SdsTypes. In other words, there is no compound indexing for secondary indexes that are on SdsStreams. For more information see [SdsStreams](xref:sdsStreams#indexes).  
 - The examples below are for compound indexes on SdsTypes and not of secondary indexes on SdsStreams.
 
 

--- a/Content_Portal/Documentation/SequentialDataStore/indexes.md
+++ b/Content_Portal/Documentation/SequentialDataStore/indexes.md
@@ -64,7 +64,7 @@ In read and write operations, specify compound indexes in the URI by ordering ea
 To help those using compound indexes, .NET client libraries methods also allow the use of tuples for indexes.
 
 **Notes:** 
-- Compound indexing only applies to SdsTypes. In other words, there is no compound indexing for secondary indexes that are on SdsStreams. For more information see [SdsStreams](xref:sdsStreams#indexes).  
+- Compound indexing only applies to SdsTypes. In other words, there is no compound indexing for secondary indexes that are on SdsStreams. For more information, see [SdsStreams](xref:sdsStreams#indexes).  
 - The examples below are for compound indexes on SdsTypes and not of secondary indexes on SdsStreams.
 
 

--- a/Content_Portal/Documentation/SequentialDataStore/indexes.md
+++ b/Content_Portal/Documentation/SequentialDataStore/indexes.md
@@ -64,7 +64,7 @@ In read and write operations, specify compound indexes in the URI by ordering ea
 To help those using compound indexes, .NET client libraries methods also allow the use of tuples for indexes.
 
 **Notes:** 
-- Compound indexing only applies to SdsTypes. There is no compound indexing for SdsStreams. 
+- Compound indexing only applies to SdsTypes. In other words, there is no compound indexing for secondary indexes which are on SdsStreams. For more information see [SdsStreams](xref:sdsStreams#indexes).  
 - The examples below are for compound indexes on SdsTypes and not of secondary indexes on SdsStreams.
 
 

--- a/Content_Portal/Documentation/SequentialDataStore/indexes.md
+++ b/Content_Portal/Documentation/SequentialDataStore/indexes.md
@@ -63,7 +63,10 @@ In read and write operations, specify compound indexes in the URI by ordering ea
  separated by the pipe character, ‘|’. 
 To help those using compound indexes, .NET client libraries methods also allow the use of tuples for indexes.
 
-**Notes:** The examples below are for compound indexes on SdsTypes and not of secondary indexes on SdsStreams.
+**Notes:** 
+- Compound indexing only applies to SdsTypes. There is no compound indexing for SdsStreams. 
+- The examples below are for compound indexes on SdsTypes and not of secondary indexes on SdsStreams.
+
 
 **REST API**
 ```text


### PR DESCRIPTION
Adding a line as part of the WI 136155.

If the primary index is a compound index, secondary indexes will only be valid if the compound index has a maximum of 2 properties.