### PR TITLE
updated code font

### DIFF
--- a/_exported_templates/default/styles/docfx.vendor.css
+++ b/_exported_templates/default/styles/docfx.vendor.css
@@ -412,7 +412,7 @@ caption,th{text-align:left}
 .blockquote-reverse .small:before,.blockquote-reverse footer:before,.blockquote-reverse small:before,blockquote.pull-right .small:before,blockquote.pull-right footer:before,blockquote.pull-right small:before{content:''}
 .blockquote-reverse .small:after,.blockquote-reverse footer:after,.blockquote-reverse small:after,blockquote.pull-right .small:after,blockquote.pull-right footer:after,blockquote.pull-right small:after{content:'\00A0 \2014'}
 code,kbd,pre,samp{font-family:Menlo,Monaco,Consolas,"Courier New",monospace}
-code{color:#c7254e;background-color:#f9f2f4;border-radius:4px}
+code{​​​​​color:#333333;background-color:#f5f5f5;border-radius:4px}​​​​​
 kbd{color:#fff;background-color:#333;border-radius:3px;-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,.25);box-shadow:inset 0 -1px 0 rgba(0,0,0,.25)}
 kbd kbd{padding:0;font-size:100%;-webkit-box-shadow:none;box-shadow:none}
 pre{padding:9.5px;margin:0 0 10px;font-size:13px;word-break:break-all;word-wrap:break-word;background-color:#f5f5f5;border:1px solid #ccc;border-radius:4px}


### PR DESCRIPTION
Hi, I made a minor change to the font that governs the color for code. 
An example of this is in the Asset API topic (Laureen, don't worry, I'm only pushing this one CSS file and not anything related to Assets).  Check out the Get Asset ID H2 heading in both production and CLGUILD to see the difference. 

We used to use a reddish font color and that is currently being used for OCS in production. I've changed the color to the dark grey that we've adopted for Edge/Adapter docs. 