### PR TITLE
Update field type eligibility

### DIFF
--- a/Content_Portal/Documentation/DataViews/DefineaDataView/Data_Items_and_Groups.md
+++ b/Content_Portal/Documentation/DataViews/DefineaDataView/Data_Items_and_Groups.md
@@ -40,7 +40,11 @@ When requesting for [resolved data items](xref:ResolvedDataViewAPI) or when [get
 The collection of ineligible data items represents OCS resources that match the queries but cannot be included in the data view. A data item is ineligible if it does not contain at least one eligible non-key [data item field](xref:ResolvedDataView#dataitemfield).
 
 A data item field is ineligible if:
-* The corresponding SDS stream's index type is different than the IndexTypeCode specified in the data view.
-* The SDS type of the corresponding stream contains compound indexes.
-* The corresponding SDS type property is nested.
-* The corresponding SDS type property is a collection type.
+* The corresponding SDS stream's index is
+  * Of a different type than the IndexTypeCode specified in the data view, or
+  * Compound.
+* The corresponding SDS property type is
+  * Complex (e.g. Object), or
+  * A collection (e.g. Array), or
+  * A timespan (TimeSpan or NullableTimeSpan)
+

--- a/Content_Portal/Documentation/DataViews/DefineaDataView/Data_Items_and_Groups.md
+++ b/Content_Portal/Documentation/DataViews/DefineaDataView/Data_Items_and_Groups.md
@@ -39,12 +39,15 @@ When requesting for [resolved data items](xref:ResolvedDataViewAPI) or when [get
 ## Ineligible Data Items
 The collection of ineligible data items represents OCS resources that match the queries but cannot be included in the data view. A data item is ineligible if it does not contain at least one eligible non-key [data item field](xref:ResolvedDataView#dataitemfield).
 
-A data item field is ineligible if:
-* The corresponding SDS stream's index is
-  * Of a different type than the IndexTypeCode specified in the data view, or
-  * Compound.
-* The corresponding SDS property type is
-  * Complex (e.g. Object), or
-  * A collection (e.g. Array), or
-  * A timespan (TimeSpan or NullableTimeSpan)
+A data item field is ineligible if its index is not appropriate for the data view, or if the field has an SdsTypeCode that may not be included in data views.
 
+#### Examples of ineligible index:
+
+* The index is compound (multiple properties)
+* The index property's SdsTypeCode differs from the IndexTypeCode of the data view
+
+#### Examples of ineligible field types:
+
+* SdsTypeCode.Object (nested type)
+* SdsTypeCode.Array (collection type)
+* SdsTypeCode.TimeSpan (time spans and nullable time spans are currently unsupported)

--- a/Content_Portal/Documentation/DataViews/DefineaDataView/Data_Items_and_Groups.md
+++ b/Content_Portal/Documentation/DataViews/DefineaDataView/Data_Items_and_Groups.md
@@ -41,12 +41,12 @@ The collection of ineligible data items represents OCS resources that match the 
 
 A data item field is ineligible if its index is not appropriate for the data view, or if the field has an SdsTypeCode that may not be included in data views.
 
-#### Examples of ineligible index:
+The following are examples of ineligible index:
 
 * The index is compound (multiple properties)
 * The index property's SdsTypeCode differs from the IndexTypeCode of the data view
 
-#### Examples of ineligible field types:
+The following are examples of ineligible field types:
 
 * SdsTypeCode.Object (nested type)
 * SdsTypeCode.Array (collection type)


### PR DESCRIPTION
Update and clarify the documentation on which data item field types are considered eligible.

Primary change: TimeSpan and NullableTimeSpan are now considered ineligible.