### PR TITLE
Incorporating existing concept topics

### DIFF
--- a/Content_Portal/Overview/what-does-ocs-do.md
+++ b/Content_Portal/Overview/what-does-ocs-do.md
@@ -41,7 +41,7 @@ A user is an individual identity that represents a person using OCS. When users 
 
 Clients have programmatic access to OCS resources through OCS APIs. There are two primary client types: 
 
-* **Client credential clients** – The most common type of OCS client, used for server-to-server communication without the presence or intervention of a user. Examples include PI Adapters or the Edge Data Store sending data to OCS. This type of client is issued a client ID and secret. After authentication, the client is granted an access token with a defined lifetime. The tokens may either be short-lived access tokens or longer-lived refresh tokens that allow the client to request new access tokens.
+* **Client credential clients** – The most common type of OCS client, used for server-to-server communication without the presence or intervention of a user. Examples include PI Adapters or the Edge Data Store sending data to OCS. This type of client is issued a client ID and secret. After authentication, the client is granted an access token with a defined lifetime. 
 
 * **Authorization code clients** – Used by web-based, mobile, and desktop applications, this client type requires user interaction. Users authenticate with an identity provider. Authorization code clients support silent refresh, which allows the user to automatically receive a new access token, providing for uninterrupted access to the application. 
 
@@ -65,7 +65,7 @@ Authorization is the process of determining the appropriate access level for a u
 
 ### Access control list 
 
-Each OCS service and resource has an access control list (ACL) that defines how much access is granted to assigned roles. The OCS Administrator configures each ACL and specifies types of permissions for each role. When a request is made to a specific OCS resource, the role assigned to the requestor (whether a user or client) is compared to the ACL for that resource to determine whether the request should be authorized. Users are granted access permissions to OCS objects based on their assigned roles and the corresponding ACLs.
+Each OCS service and resource has an access control list (ACL) that defines how much access is granted to assigned roles. The OCS Administrator configures each ACL and specifies types of permissions for each role. When a request is made to a specific OCS resource, the role assigned to the requestor (whether a user or client) is compared to the ACL for that resource to determine whether the request should be authorized. Users are allowed or denied access permissions to OCS objects based on their assigned roles and the corresponding ACLs.
 
 The types of permissions granted to roles are as follows:
 * Read

--- a/Content_Portal/Overview/what-does-ocs-do.md
+++ b/Content_Portal/Overview/what-does-ocs-do.md
@@ -41,7 +41,7 @@ A user is an individual identity that represents a person using OCS. When users 
 
 Clients have programmatic access to OCS resources through OCS APIs. There are two primary client types: 
 
-* **Client credential clients** – The most common type of OCS client, used for server-to-server communication without the presence or intervention of a user. Examples include PI Adapters or the Edge Data Store sending data to OCS. This type of client is issued a client ID and secret. After authentication, the client is granted an access token with a defined lifetime. 
+* **Client credential clients** – The most common type of OCS client, used for server-to-server communication without the presence or intervention of a user. Examples include PI Adapters or the Edge Data Store sending data to OCS. This type of client is issued a client ID and secret. After authentication, the client is granted an access token with a defined lifetime. The tokens may either be short-lived access tokens or longer-lived refresh tokens that allow the client to request new access tokens.
 
 * **Authorization code clients** – Used by web-based, mobile, and desktop applications, this client type requires user interaction. Users authenticate with an identity provider. Authorization code clients support silent refresh, which allows the user to automatically receive a new access token, providing for uninterrupted access to the application. 
 
@@ -65,7 +65,7 @@ Authorization is the process of determining the appropriate access level for a u
 
 ### Access control list 
 
-Each OCS service and resource has an access control list (ACL) that defines how much access is granted to assigned roles. The OCS Administrator configures each ACL and specifies types of permissions for each role. When a request is made to a specific OCS resource, the role assigned to the requestor (whether a user or client) is compared to the ACL for that resource to determine whether the request should be authorized. 
+Each OCS service and resource has an access control list (ACL) that defines how much access is granted to assigned roles. The OCS Administrator configures each ACL and specifies types of permissions for each role. When a request is made to a specific OCS resource, the role assigned to the requestor (whether a user or client) is compared to the ACL for that resource to determine whether the request should be authorized. Users are granted access permissions to OCS objects based on their assigned roles and the corresponding ACLs.
 
 The types of permissions granted to roles are as follows:
 * Read

--- a/Content_Portal/set-up/clients-concept.md
+++ b/Content_Portal/set-up/clients-concept.md
@@ -51,7 +51,7 @@ The following best practices are recommended when you use an authorization code 
 
 ## <a name="hybrid-client"></a>Introduction to hybrid clients
 
-Hybrid clients are used by native and server-side web applications. Authentication can be performed using any browser. The server-side code retrieves an access token and a refresh token can also be provided.
+Hybrid clients are used by native and server-side web applications. This client utilizes the user credentials to authenticate with the identity provider. Once the user is authenticated, then the server-side client steps in and server-to-server communication commences. Authentication can be performed using any browser. The server-side code retrieves an access token and a refresh token can also be provided.
 
 ### <a name="hybrid-client-pi-core"></a>Hybrid client PI Core counterpart
 

--- a/Content_Portal/set-up/roles-concept.md
+++ b/Content_Portal/set-up/roles-concept.md
@@ -7,7 +7,7 @@ Roles are used to manage access to assets, resources, and services in OSIsoft Cl
 
 There are five built-in roles which cannot be removed from a tenant.
 
-- **Tenant Administrator** - OCS Administrator of OCS who is granted full permissions throughout OCS, by default.
+- **Tenant Administrator** - OCS Administrator of OCS who is granted full permissions throughout OCS, by default. This is the highest privilege role, with the ability to create new and remove existing users, clients and secrets. OSIsoft recommends not assigning this role to clients.
 - **Tenant Contributor** - Granted read and write permissions throughout OCS, by default.
 - **Tenant Data Steward** - No specific permissions are granted to this role, by default.
 - **Tenant Viewer** - No specific permissions are granted to this role, by default.


### PR DESCRIPTION
Incorporating any content in the existing concept topics that doesn't appear in the Reorg TOC branch.

I examined the content found in the 3 existing concept topics (introduction-to-data-storage.md, introduction-to-preconfigured-roles, introduction-to-account-management) for information that doesn't exist in the lasato-ocs_docs_reorg branch topics. I added the information into suitable topics within the lasato-ocs_docs_reorg branch.
The reason is that the 3 existing concept topics are going away and we want to preserve relevant information to the customer.