### PR TITLE
Added Josh's feedback about ACLs and roles

### DIFF
--- a/Content_Portal/set-up/roles-concept.md
+++ b/Content_Portal/set-up/roles-concept.md
@@ -5,7 +5,6 @@ uid: ccRoles
 
 Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). Roles are assigned to identities, which includes users, groups, and client-credentials clients. When an identity attempts to access a resource in OCS, the identity's list of roles is compared against the permissions on the resource to determine whether access is allowed.
 
-<!--- Josh Kim Mar19021: Similar to the comment as before where it seemed to me that this sentence implied roles were the primary factor in getting access, when in fact it is the roles of the users compared against the provisioned ACL that grants access. Do we want to communicate this? --->
 
 There are five built-in roles which cannot be removed from a tenant.
 

--- a/Content_Portal/set-up/roles-concept.md
+++ b/Content_Portal/set-up/roles-concept.md
@@ -3,7 +3,9 @@ uid: ccRoles
 ---
 # About roles
 
-Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). Roles are assigned to identities, which includes users, groups, and client-credentials clients. <!--- Josh Kim Mar19021: Similar to the comment as before where it seemed to me that this sentence implied roles were the primary factor in getting access, when in fact it is the roles of the users compared against the provisioned ACL that grants access. Do we want to communicate this? --->
+Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). Roles are assigned to identities, which includes users, groups, and client-credentials clients. 
+
+<!--- Josh Kim Mar19021: Similar to the comment as before where it seemed to me that this sentence implied roles were the primary factor in getting access, when in fact it is the roles of the users compared against the provisioned ACL that grants access. Do we want to communicate this? --->
 
 There are five built-in roles which cannot be removed from a tenant.
 

--- a/Content_Portal/set-up/roles-concept.md
+++ b/Content_Portal/set-up/roles-concept.md
@@ -16,8 +16,7 @@ There are five built-in roles which cannot be removed from a tenant.
 
 In addition, you can create custom roles which are not granted any specific permissions, by default. 
 
-Simply assigning a role to a user or client does not determine access. This is defined when a role is explicitly allowed or denied access to OCS resources through an access control list (ACL). An ACL is created for each OCS resource and it defines which roles have access to the resource. <!-- Josh: I think I'd like to keep the discussion about ACLs brief. Can you tell me if what I've said here is correct? -->
-<!--- Josh Kim Mar19021: Perfect! --->
+Simply assigning a role to a user or client does not determine access. This is defined when a role is explicitly allowed or denied access to OCS resources.
 
 For any resource in OCS, permissions are allowed or denied for specific roles, rather than to specific users or clients. These permissions are managed using the **Manage Permissions** dialog for the given resource. Each role can be allowed or denied access to one or more of the following access types: **Read**, **Write**, **Delete**, and **Manage Permissions**.
 

--- a/Content_Portal/set-up/roles-concept.md
+++ b/Content_Portal/set-up/roles-concept.md
@@ -3,7 +3,7 @@ uid: ccRoles
 ---
 # About roles
 
-Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). Roles are assigned to identities, which includes users, groups, and client-credentials clients. 
+Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). Roles are assigned to identities, which includes users, groups, and client-credentials clients. When an identity attempts to access a resource in OCS, the identity's list of roles is compared against the permissions on the resource to determine whether access is allowed.
 
 <!--- Josh Kim Mar19021: Similar to the comment as before where it seemed to me that this sentence implied roles were the primary factor in getting access, when in fact it is the roles of the users compared against the provisioned ACL that grants access. Do we want to communicate this? --->
 

--- a/Content_Portal/set-up/roles-procedure.md
+++ b/Content_Portal/set-up/roles-procedure.md
@@ -7,7 +7,6 @@ Roles are used to manage access to assets, resources, and services in OSIsoft Cl
 
  <!-- Josh Kim: Roles are assigned to identities. It is the OCS object, specifically the ACL, that determines whether the identity gets access. This is done by comparing the assigned role of the identity to the OCS object's ACL. I wonder if the first sentence gives the impression that Roles is only factor in gaining access? -->
 
-or perhaps this should be our recommended message to customers to simplify access? Could we ask readiness/architects how detailed we want to be about describing access?
 
 - [About roles](xref:ccRoles)
 - [PI Core counterpart](xref:ccRoles#roles-pi-core)

--- a/Content_Portal/set-up/roles-procedure.md
+++ b/Content_Portal/set-up/roles-procedure.md
@@ -5,7 +5,6 @@ uid: gpRoles
 
 Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). Roles are assigned to identities, which includes users, groups, and client-credentials clients. See the following for more information about roles:
 
- <!-- Josh Kim: Roles are assigned to identities. It is the OCS object, specifically the ACL, that determines whether the identity gets access. This is done by comparing the assigned role of the identity to the OCS object's ACL. I wonder if the first sentence gives the impression that Roles is only factor in gaining access? -->
 
 
 - [About roles](xref:ccRoles)

--- a/Content_Portal/set-up/roles-procedure.md
+++ b/Content_Portal/set-up/roles-procedure.md
@@ -5,6 +5,10 @@ uid: gpRoles
 
 Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). Roles are assigned to identities, which includes users, groups, and client-credentials clients. See the following for more information about roles:
 
+ <!-- Josh Kim: Roles are assigned to identities. It is the OCS object, specifically the ACL, that determines whether the identity gets access. This is done by comparing the assigned role of the identity to the OCS object's ACL. I wonder if the first sentence gives the impression that Roles is only factor in gaining access? -->
+
+or perhaps this should be our recommended message to customers to simplify access? Could we ask readiness/architects how detailed we want to be about describing access?
+
 - [About roles](xref:ccRoles)
 - [PI Core counterpart](xref:ccRoles#roles-pi-core)
 - [Roles best practices](xref:ccRoles#roles-bp)

--- a/Content_Portal/set-up/roles-procedure.md
+++ b/Content_Portal/set-up/roles-procedure.md
@@ -3,7 +3,7 @@ uid: gpRoles
 ---
 # Add a role
 
-Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). Roles are assigned to identities, which includes users, groups, and client-credentials clients. See the following for more information about roles:
+Roles are used to manage access to assets, resources, and services in OSIsoft Cloud Services (OCS). See the following for more information about roles:
 
 
 


### PR DESCRIPTION
Hi Doug and Derek,

One of the OCS writers raised a question about how we talk about roles being the mechanism by which users' permissions to OCS resources is determined. The question is whether we should be clearer that it is a combination of roles and ACLs that determine whether a user has access to a resource or not.

Please take a look at Josh's comments and see what you think. Thanks