### PR TITLE
Patch 5

### DIFF
--- a/content/external-references/dataviews-response-examples.yaml
+++ b/content/external-references/dataviews-response-examples.yaml
@@ -1,30 +1,5 @@
 # data responses
-data-get-csv:
-  type: markdown
-  value: |
-    ```csv
-    form=csv
-    HTTP 200 OK
-    Content-Type: text/csv
-    2018-01-01T00:00:00Z,24,44,245
-    2018-01-01T00:00:01Z,24,44,245
-    2018-01-01T00:00:02Z,24,44,245
-    ```
-
-data-get-csvh:
-  type: markdown
-  value: |
-    ```csv
-    form=csvh
-    HTTP 200 OK
-    Content-Type: text/csv
-    Time,Temperature,Flowrate,Volume
-    2018-01-01T00:00:00Z,24,44,245
-    2018-01-01T00:00:01Z,24,44,245
-    2018-01-01T00:00:02Z,24,44,245
-    ```
-
-data-get-default:
+data-get-multiple-formats:
   type: markdown
   value: |
     ```json
@@ -52,9 +27,26 @@ data-get-default:
         }
     ]
     ```
-data-get-table:
-  type: markdown
-  value: |
+
+    ```csv
+    form=csv
+    HTTP 200 OK
+    Content-Type: text/csv
+    2018-01-01T00:00:00Z,24,44,245
+    2018-01-01T00:00:01Z,24,44,245
+    2018-01-01T00:00:02Z,24,44,245
+    ```
+
+    ```csv
+    form=csvh
+    HTTP 200 OK
+    Content-Type: text/csv
+    Time,Temperature,Flowrate,Volume
+    2018-01-01T00:00:00Z,24,44,245
+    2018-01-01T00:00:01Z,24,44,245
+    2018-01-01T00:00:02Z,24,44,245
+    ```
+
     ```json
     form=table
     HTTP 200 OK
@@ -101,9 +93,6 @@ data-get-table:
     }
     ```
 
-data-get-tableh:
-  type: markdown
-  value: |
     ```json
     form=tableh
     HTTP 200 OK

--- a/content/external-references/dataviews-summaries.yaml
+++ b/content/external-references/dataviews-summaries.yaml
@@ -19,6 +19,10 @@ class-dataviewscontroller:
   value: |
     The `DataView` API provides mechanisms to create, read, update, and delete data views. This is one portion of the whole [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html).
 
+    For a description of the `DataView` object type, see the [DataView documentation](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/Data_Views_Overview.html).
+
+    Other sections of documentation describe how to [secure data views](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/SecureDataViews/Securing_Data_Views.html) by setting their ownership and permissions, and the corresponding [API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Access_Control_API.html).
+
 class-dataviewpermissionscontroller:
   type: text/plain
   value: |

--- a/content/external-references/dataviews-summaries.yaml
+++ b/content/external-references/dataviews-summaries.yaml
@@ -2,22 +2,43 @@
 class-collectionaccessrightscontroller:
   type: text/plain
   value: |
-    API for retrieving access rights on the data views collection
+    APIs for retrieving access rights on the data views collection
 
 class-collectionaclcontroller:
   type: text/plain
   value: |
-    APIs for working with Data View collection Access Control Lists
+    APIs for working with the Access Control List of the data view collection
+
+class-dataqueriescontroller:
+  type: text/plain
+  value: |
+    The Data API allows users to [retrieve data](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/GetDataViewData/Quick_Start_Get_Data_View_Data.html) for a specified data view.  This API is one portion of the [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html).
 
 class-dataviewscontroller:
   type: text/plain
   value: |
-    APIs for working with Data Views
+    The `DataView` API provides mechanisms to create, read, update, and delete data views. This is one portion of the whole [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html).
+
+class-dataviewpermissionscontroller:
+  type: text/plain
+  value: |
+    This portion of the [overall data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html) focuses on [securing data views](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/SecureDataViews/Securing_Data_Views.html) by setting their ownership and permissions.
 
 class-dataviewspreviewcontroller:
   type: text/plain
   value: |
-    APIs for previewing data view methods without saving the data view
+    This portion of the overall [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html) specifies the resources that resolve per-user for an input data view. 
+    The preview APIs require a data view to be passed in the request body for each request, which provides the user the flexibility to change the data view on the fly without saving/updating it.
+
+class-previewdataqueriescontroller:
+  type: text/plain
+  value: |
+    The Preview Data API allows users to [retrieve data](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/GetDataViewData/Quick_Start_Get_Data_View_Data.html) for a specified data view.  This API is one portion of the [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html).
+
+class-resolveddataviewscontroller:
+  type: text/plain
+  value: |
+    This portion of the overall [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html) is the resources that resolve per-user for each data view. For a description of what this information is, and how to use it, see the [documentation](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/GetResolvedDataView/Resolved_Data_View.html) for resolved data views.
 
 # method summaries: access control
 dataview-accessrights-get:

--- a/content/external-references/dataviews-summaries.yaml
+++ b/content/external-references/dataviews-summaries.yaml
@@ -31,8 +31,7 @@ class-dataviewpermissionscontroller:
 class-dataviewspreviewcontroller:
   type: text/plain
   value: |
-    This portion of the overall [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html) specifies the resources that resolve per-user for an input data view. 
-    The preview APIs require a data view to be passed in the request body for each request, which provides the user the flexibility to change the data view on the fly without saving/updating it.
+    This portion of the overall [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html) specifies the resources that resolve per-user for an input data view. The preview APIs require a data view to be passed in the request body for each request, which provides the user the flexibility to change the data view on the fly without saving/updating it.
 
 class-previewdataqueriescontroller:
   type: text/plain

--- a/content/external-references/dataviews-summaries.yaml
+++ b/content/external-references/dataviews-summaries.yaml
@@ -10,12 +10,12 @@ class-collectionaclcontroller:
     APIs for working with the Access Control List of the data view collection
 
 class-dataqueriescontroller:
-  type: text/plain
+  type: markdown
   value: |
     The Data API allows users to [retrieve data](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/GetDataViewData/Quick_Start_Get_Data_View_Data.html) for a specified data view.  This API is one portion of the [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html).
 
 class-dataviewscontroller:
-  type: text/plain
+  type: markdown
   value: |
     The `DataView` API provides mechanisms to create, read, update, and delete data views. This is one portion of the whole [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html).
 
@@ -24,22 +24,22 @@ class-dataviewscontroller:
     Other sections of documentation describe how to [secure data views](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/SecureDataViews/Securing_Data_Views.html) by setting their ownership and permissions, and the corresponding [API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Access_Control_API.html).
 
 class-dataviewpermissionscontroller:
-  type: text/plain
+  type: markdown
   value: |
     This portion of the [overall data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html) focuses on [securing data views](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/SecureDataViews/Securing_Data_Views.html) by setting their ownership and permissions.
 
 class-dataviewspreviewcontroller:
-  type: text/plain
+  type: markdown
   value: |
     This portion of the overall [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html) specifies the resources that resolve per-user for an input data view. The preview APIs require a data view to be passed in the request body for each request, which provides the user the flexibility to change the data view on the fly without saving/updating it.
 
 class-previewdataqueriescontroller:
-  type: text/plain
+  type: markdown
   value: |
     The Preview Data API allows users to [retrieve data](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/GetDataViewData/Quick_Start_Get_Data_View_Data.html) for a specified data view.  This API is one portion of the [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html).
 
 class-resolveddataviewscontroller:
-  type: text/plain
+  type: markdown
   value: |
     This portion of the overall [data views API](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/DataViewsAPIOverview/Data_Views_API_Overview.html) is the resources that resolve per-user for each data view. For a description of what this information is, and how to use it, see the [documentation](https://ocs-docs.osisoft.com/Content_Portal/Documentation/DataViews/GetResolvedDataView/Resolved_Data_View.html) for resolved data views.
 


### PR DESCRIPTION
Revised a data query response example to illustrate multiple response formats (csv, table, etc.)  Docupipe supports one example per response type.

Revised external dataviews-summaries so the controller summaries matched what was in the current public facing documentation.