### PR TITLE
Match file name with the toc title

### DIFF
--- a/content/api-reference/identity/toc.yml
+++ b/content/api-reference/identity/toc.yml
@@ -20,9 +20,9 @@
   href: identity-invitations.md
 - name: Secrets
   href: identity-secrets.md
-- name: Tenant roles
+- name: Tenants roles
   href: identity-tenants-roles.md
-- name: User roles
+- name: Users roles
   href: identity-users-roles.md
 - name: Users
   href: identity-tenants-users.md 

--- a/content/api-reference/identity/toc.yml
+++ b/content/api-reference/identity/toc.yml
@@ -24,5 +24,5 @@
   href: identity-tenants-roles.md
 - name: Users roles
   href: identity-users-roles.md
-- name: Users
+- name: Tenants Users
   href: identity-tenants-users.md 


### PR DESCRIPTION
DocuPipe is now updated to match the file name with the h1 header. But the title in the toc still has the old name. Updating the toc once to make sure that they're in line. 