### PR TITLE
Added "OCS" to "tenant identifier; added an aadQuery key

### DIFF
--- a/content/external-references/parameters.yaml
+++ b/content/external-references/parameters.yaml
@@ -5,7 +5,7 @@ namespaceId:
 tenantId:
   type: text/plain
   value: |
-    Tenant identifier
+    OCS tenant identifier
 aadTenantId:
   type: text/plain
   value: |
@@ -18,6 +18,10 @@ aadSkip:
   type: text/plain
   value: |
     Number of Azure Active Directory tenants to skip
+aadQuery:
+  type: text/plain
+  value: |
+    (Not supported) Query identifier
 groupId:
   type: text/plain
   value: |

--- a/content/external-references/parameters.yaml
+++ b/content/external-references/parameters.yaml
@@ -5,11 +5,15 @@ namespaceId:
 tenantId:
   type: text/plain
   value: |
-    OCS tenant identifier
+    Tenant identifier
 aadTenantId:
   type: text/plain
   value: |
     Azure Active Directory tenant identifier
+tenantId-OCS:
+  type: text/plain
+  value: |
+    OCS tenant identifier
 aadCount:
   type: text/plain
   value: |


### PR DESCRIPTION
Added the qualilfication "OCS" to tenantId description because we deal with an Azure Active Directory tenant.
Added a new key for query for Azure Active Directory