### PR TITLE
Removed the erroneous internal "TODO: Remove the internal model" comments from 9 API markdown topics

### DIFF
--- a/content/api-reference/identity/identity-claims.md
+++ b/content/api-reference/identity/identity-claims.md
@@ -415,7 +415,7 @@ Object representing a claim from an identity provider to map to a role
 <a id="tocSerrorresponse"></a>
 <a id="tocserrorresponse"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 

--- a/content/api-reference/identity/identity-client-credential-clients-roles.md
+++ b/content/api-reference/identity/identity-client-credential-clients-roles.md
@@ -412,7 +412,7 @@ The object that represents the scope of a given role
 <a id="tocSerrorresponse"></a>
 <a id="tocserrorresponse"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 

--- a/content/api-reference/identity/identity-client-credential-clients.md
+++ b/content/api-reference/identity/identity-client-credential-clients.md
@@ -769,7 +769,7 @@ Object to get or update a ClientCredentialClient
 <a id="tocSerrorresponse"></a>
 <a id="tocserrorresponse"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 
@@ -843,7 +843,7 @@ Object used during Client creation.
 <a id="tocSclientcredentialclientmultistatusresponse"></a>
 <a id="tocsclientcredentialclientmultistatusresponse"></a>
 
-MultiStatusResponse objects returned in a 207 response. TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+MultiStatusResponse objects returned in a 207 response
 
 #### Properties
 
@@ -899,7 +899,7 @@ MultiStatusResponse objects returned in a 207 response. TODO: Remove this intern
 <a id="tocSmultistatusresponsechilderror"></a>
 <a id="tocsmultistatusresponsechilderror"></a>
 
-ChildError objects returned in a 207 response. TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+ChildError objects returned in a 207 response
 
 #### Properties
 

--- a/content/api-reference/identity/identity-hybrid-clients.md
+++ b/content/api-reference/identity/identity-hybrid-clients.md
@@ -873,7 +873,7 @@ Object used for Hybrid Clients.
 <a id="tocSerrorresponse"></a>
 <a id="tocserrorresponse"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 

--- a/content/api-reference/identity/identity-identity-providers.md
+++ b/content/api-reference/identity/identity-identity-providers.md
@@ -1223,7 +1223,7 @@ The model for the group level capabilities of an identity provider
 <a id="tocSerrorresponse"></a>
 <a id="tocserrorresponse"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 
@@ -1255,7 +1255,7 @@ Object returned whenever there is an error TODO: Remove this internal model and 
 <a id="tocSidentityproviderconsent"></a>
 <a id="tocsidentityproviderconsent"></a>
 
-The model for an identity provider consent in identity storage. TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+The model for an identity provider consent in identity storage
 
 #### Properties
 

--- a/content/api-reference/identity/identity-invitations.md
+++ b/content/api-reference/identity/identity-invitations.md
@@ -722,7 +722,7 @@ Object used to create or update an invitation.
 <a id="tocSerrorresponse2"></a>
 <a id="tocserrorresponse2"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 

--- a/content/api-reference/identity/identity-tenants-roles.md
+++ b/content/api-reference/identity/identity-tenants-roles.md
@@ -627,7 +627,7 @@ The object that represents the scope of a given role
 <a id="tocSerrorresponse"></a>
 <a id="tocserrorresponse"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 

--- a/content/api-reference/identity/identity-tenants-users.md
+++ b/content/api-reference/identity/identity-tenants-users.md
@@ -1025,7 +1025,7 @@ Object for retrieving a user
 <a id="tocSusermultistatusresponse"></a>
 <a id="tocsusermultistatusresponse"></a>
 
-MultiStatusResponse objects returned in a 207 response. TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+MultiStatusResponse objects returned in a 207 response
 
 #### Properties
 
@@ -1084,7 +1084,7 @@ MultiStatusResponse objects returned in a 207 response. TODO: Remove this intern
 <a id="tocSmultistatusresponsechilderror"></a>
 <a id="tocsmultistatusresponsechilderror"></a>
 
-ChildError objects returned in a 207 response. TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+ChildError objects returned in a 207 response
 
 #### Properties
 
@@ -1120,7 +1120,7 @@ ChildError objects returned in a 207 response. TODO: Remove this internal model 
 <a id="tocSerrorresponse"></a>
 <a id="tocserrorresponse"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 
@@ -1253,7 +1253,7 @@ Object when updating a user.
 <a id="tocSuserstatusmultistatusresponse"></a>
 <a id="tocsuserstatusmultistatusresponse"></a>
 
-MultiStatusResponse objects returned in a 207 response. TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+MultiStatusResponse objects returned in a 207 response
 
 #### Properties
 

--- a/content/api-reference/identity/identity-users-roles.md
+++ b/content/api-reference/identity/identity-users-roles.md
@@ -240,7 +240,7 @@ The object that represents the scope of a given role
 <a id="tocSerrorresponse"></a>
 <a id="tocserrorresponse"></a>
 
-Object returned whenever there is an error TODO: Remove this internal model and re-adopt public model when moving to System.Text.Json in WI 202168.
+Object returned whenever there is an error
 
 #### Properties
 


### PR DESCRIPTION
Removed the "TODO: Remove the internal model" sentence from 9 API markdown files.
I will address this in the codebase shortly, but this is to fix in the immediate term on ZoomIn