### PR TITLE
Edits for consistency

### DIFF
--- a/content/add-organize-data/store-data/types/types-concept.md
+++ b/content/add-organize-data/store-data/types/types-concept.md
@@ -4,10 +4,14 @@ uid: ccTypes
 
 # Types
 
-Sequential Data Store (SDS) types define the shape and structure of events and how to associate events within a stream of data. An SDS type is comprised of at least two properties. One property serves as the primary index, most commonly a timestamp or DateTime. In addition, it has one or more additional properties called value properties which describes the data in each stream event. Each value property can have a different property type. For example, In the "Get Started with Types" procedure below, you create two value properties with Ids called Temperature and Pressure. A wide variety of property types are supported. For a list of the supported property types, see [Supported Types](xref:sdsTypes#sdstypecode). Note: You can also create complex secondary indexes. SDS types are immutable. Once created, they cannot be updated. Therefore, it is important to determine the correct type definition before you begin building streams and data in the Sequential Data Store.
+Sequential Data Store (SDS) types define the shape and structure of events and how to associate events within a stream of data. An SDS type is comprised of at least two properties. One property serves as the primary index, most commonly a timestamp or DateTime. In addition, it has one or more additional properties called value properties which describes the data in each stream event. Each value property can have a different property type. A wide variety of property types are supported. For a list of the supported property types, see [Supported Types](xref:sdsTypes#sdstypecode). 
 
-For more information, see [Types](xref:sdsTypes).
+**Note:** You can also create complex secondary indexes. 
+
+SDS types are immutable; once created, they cannot be updated. Therefore, it is important to determine the correct type definition before you begin building streams and data in the Sequential Data Store.
+
+For more information, see [Types](xref:sdsTypes) in the API reference section.
 
 ### <a name="types-pi-server"></a>PI Server counterpart
 
-An SDS type is comparable to PI point type in PI Data Archive. For example, a PI point of type float32 is comparable to an SDS type with a DateTime index property and a float32 value property. Because they are similar, if you use PI to OCS to import data into SDS, some "PI-\*" types are created automatically in SDS that map to existing PI point types. PI Data Archive has a predefined list of supported PI point types. The data structure of the Sequential Data Store is more flexible because SDS types can include multiple data measurements of different data types, and data can be indexed using a non-time-series index or multiple indexes. 
+An SDS type is comparable to a PI point type in PI Data Archive. For example, a PI point of type float32 is comparable to an SDS type with a DateTime index property and a float32 value property. Because they are similar, if you use PI to OCS to import data into SDS, some "PI-\*" types are created automatically in SDS that map to existing PI point types. PI Data Archive has a predefined list of supported PI point types. The data structure of the Sequential Data Store is more flexible because SDS types can include multiple data measurements of different data types, and data can be indexed using a non-time-series index or multiple indexes. 


### PR DESCRIPTION
It appears that the subheadings in "Create and configure an asset" and "Create an asset type with the asset types editor" already appear in the In This Topic links. Therefore, I did not make any changes to these topics.