### PR TITLE
Adding periods (.) to all external references

### DIFF
--- a/content/external-references/common.yaml
+++ b/content/external-references/common.yaml
@@ -2,15 +2,15 @@
 namespaceId:
   type: text/plain
   value: |
-    Namespace identifier
+    Namespace identifier.
 tenantId:
   type: text/plain
   value: |
-    Tenant identifier
+    Tenant identifier.
 query:
   type: text/plain
   value: |
-    Query identifier
+    Query identifier.
 count:
   type: text/plain
   value: |
@@ -22,104 +22,104 @@ skip:
 key:
   type: text/plain
   value: |
-    Key specifying the metadata value of interest
+    Key specifying the metadata value of interest.
 cancellation-token:
   type: text/plain
   value: |
-    Cancellation token
+    Cancellation token.
 scheme:
   type: text/plain
   value: |
-    Scheme name (for example, AAD or Google)
+    Scheme name (for example, AAD or Google).
 # Community parameters
 tenantId-community:
   type: text/plain
   value: |
-    Owning tenant identifier
+    Owning tenant identifier.
 communityId:
   type: text/plain
   value: |
-    Community identifier
+    Community identifier.
 query-community:
   type: text/plain
   value: |
-    (Not supported) Query identifier
+    (Not supported) Query identifier.
 # Tenant identifier parameters for AAD when there are different types of tenants to have to consider and distinguish
 tenantId-OCS:
   type: text/plain
   value: |
-    OCS tenant identifier
+    OCS tenant identifier.
 tenantId-aad:
   type: text/plain
   value: |
-    Azure Active Directory tenant identifier
+    Azure Active Directory tenant identifier.
 groupId:
   type: text/plain
   value: |
-    Group identifier
+    Group identifier.
 clientId:
   type: text/plain
   value: |
-    Client identifier
+    Client identifier.
 streamId:
   type: text/plain
   value: |
-    Stream identifier
+    Stream identifier.
 # Identity provider focused identifiers
 identityProviderId:
   type: text/plain
   value: |
-    Identity provider identifier
+    Identity provider identifier.
 identityProviderClaimId:
   type: text/plain
   value: |
-    Identity provider claim identifier
+    Identity provider claim identifier.
 identityProviderTypeNameClaimId:
   type: text/plain
   value: |
-    Identity provider claim type name identifier
+    Identity provider claim type name identifier.
 # Other types of identifiers
 invitationId:
   type: text/plain
   value: |
-    Invitation identifier
+    Invitation identifier.
 userId:
   type: text/plain
   value: |
-    User identifier
+    User identifier.
 datasourceId:
   type: text/plain
   value: |
-    Data source identifier
+    Data source identifier.
 dataViewId:
   type: text/plain
   value: |
-    Data view identifier
+    Data view identifier.
 secretId:
   type: text/plain
   value: |
-    Secret identifier
+    Secret identifier.
 regionId:
   type: text/plain
   value: |
-    The region identifier
+    The region identifier.
 featurestateId:
   type: text/plain
   value: |
-    Feature state identifier
+    Feature state identifier.
 blogId:
   type: text/plain
   value: |
-    Service blog identifier
+    Service blog identifier.
 # OMF parameters
 subscriptionId:
   type: text/plain
   value: |
-    Subscription identifier
+    Subscription identifier.
 topicId:
   type: text/plain
   value: |
-    Topic identifier
+    Topic identifier.
 # Used for getting a list of identifiers in a GET method
 id:
   type: text/plain
@@ -128,66 +128,66 @@ id:
 tag:
   type: text/plain
   value: |
-    Only return clients that have these tags
+    Only return clients that have these tags.
 # Query for wildcard search 
 query-searchstring:
   type: text/plain
   value: |
-    (Not supported) Search string identifier
+    (Not supported) Search string identifier.
 # Response codes
 200:
   type: text/plain
   value: |
-    Success
+    Success.
 201:
   type: text/plain
   value: |
-    Created
+    Created.
 204:
   type: text/plain
   value: |
-    Deleted
+    Deleted.
 207:
   type: text/plain
   value: |
-    Partial
+    Partial.
 302:
   type: text/plain
   value: |
-    Found 
+    Found.
 400:
   type: text/plain
   value: |
-    Missing or invalid inputs
+    Missing or invalid inputs.
 401:
   type: text/plain
   value: |
-    Unauthorized
+    Unauthorized.
 403:
   type: text/plain
   value: |
-    Forbidden
+    Forbidden.
 404:
   type: text/plain
   value: |
-    Client or tenant not found
+    Client or tenant not found.
 408:
   type: text/plain
   value: |
-    Operation timed out
+    Operation timed out.
 409:
   type: text/plain
   value: |
-    Found
+    Found.
 412:
   type: text/plain
   value: |
-    Precondition failed
+    Precondition failed.
 500:
   type: text/plain
   value: |
-    Internal server error
+    Internal server error.
 503:
   type: text/plain
   value: |
-    Service unavailable
+    Service unavailable.

--- a/content/external-references/dataviews-headers.yaml
+++ b/content/external-references/dataviews-headers.yaml
@@ -2,7 +2,7 @@
 first-page-standard-message:
   type: text/plain
   value: |
-    Hyperlink to the first page of results
+    Hyperlink to the first page of results.
 
 # Link 
 link-data-get:
@@ -13,31 +13,31 @@ link-data-get:
 link-standard-message:
   type: text/plain
   value: |
-    Hyperlinks to the first page and next page of results as applicable
+    Hyperlinks to the first page and next page of results as applicable.
 
 # Next-Page
 next-page-standard-message:
   type: text/plain
   value: |
-    Hyperlink to the next page of results
+    Hyperlink to the next page of results.
 
 # Total-Count 
 total-count-dataitems:
   type: text/plain
   value: |
-    The total count of data items visible to the current user
+    The total count of data items visible to the current user.
 
 total-count-dataviews:
   type: text/plain
   value: |
-    The total count of data views visible to the current user
+    The total count of data views visible to the current user.
 
 total-count-fieldmappings:
   type: text/plain
   value: |
-    The total count of field mappings
+    The total count of field mappings.
 
 total-count-groups:
   type: text/plain
   value: |
-    The total count of groups
+    The total count of groups.

--- a/content/external-references/dataviews-parameters.yaml
+++ b/content/external-references/dataviews-parameters.yaml
@@ -2,14 +2,14 @@
 acl:
   type: markdown
   value: |
-    An [`AccessControlList`](https://ocs-docs.osisoft.com/Content_Portal/Documentation/Access_Control.html#access-control-lists)
+    An [`AccessControlList`](https://ocs-docs.osisoft.com/Content_Portal/Documentation/Access_Control.html#access-control-lists).
 
 # cache
 cache:
   type: text/plain
   value: |
     "Refresh" to force the resource to re-resolve.
-    "Preserve" to use cached information, if available. This is the default value
+    "Preserve" to use cached information, if available. This is the default value.
 
 cache-data:
   type: markdown
@@ -98,7 +98,7 @@ interval:
 owner:
   type: markdown
   value: |
-    A [`Trustee`](https://ocs-docs.osisoft.com/Content_Portal/Documentation/Access_Control.html#owner)
+    A [`Trustee`](https://ocs-docs.osisoft.com/Content_Portal/Documentation/Access_Control.html#owner).
 
 # skip
 skip-dataitems:
@@ -122,4 +122,4 @@ skip-groups:
 start-index:
   type: markdown
   value: |
-    The requested start index, inclusive. The default value is the ```.DefaultStartIndex``` of the data view. Optional if a default value is specified
+    The requested start index, inclusive. The default value is the ```.DefaultStartIndex``` of the data view. Optional if a default value is specified.

--- a/content/external-references/dataviews-response-codes.yaml
+++ b/content/external-references/dataviews-response-codes.yaml
@@ -8,12 +8,12 @@
 200-dataview-accessrights-get:
   type: text/plain
   value: |
-    A list of access rights to the requested data view
+    A list of access rights to the requested data view.
 
 200-dataview-acl-get:
   type: text/plain
   value: |
-    The access control list of the requested data view
+    The access control list of the requested data view.
 
 200-dataitems-get:
   type: markdown
@@ -28,17 +28,17 @@
 200-dataview-owner-get:
   type: text/plain
   value: |
-    The owner of the requested data view
+    The owner of the requested data view.
 
 200-dataviews-acl-get:
   type: text/plain
   value: |
-    The default access control list of the data views collection
+    The default access control list of the data views collection.
 
 200-dataviews-accessrights-get:
   type: text/plain
   value: |
-    A list of access rights to the data views collection
+    A list of access rights to the data views collection.
 
 200-dataviews-get:
   type: text/plain
@@ -53,7 +53,7 @@
 200-fieldsets-get:
   type: markdown
   value: |
-    An object with a "TimeOfResolution" and a collection of "Items", the `FieldSet`s that resolved and which are still available
+    An object with a "TimeOfResolution" and a collection of "Items", the `FieldSet`s that resolved and which are still available.
 
 200-groups-get:
   type: markdown
@@ -75,28 +75,28 @@
 204-dataview-update-standard-message:
   type: text/plain
   value: |
-    Successfully updated the data view
+    Successfully updated the data view.
 
 204-dataview-acl-update:
   type: text/plain
   value: |
-    Successfully updated the data view access control list
+    Successfully updated the data view access control list.
 
 204-dataviews-acl-update:
   type: text/plain
   value: |
-    Successfully updated the default access control list of the data views collection
+    Successfully updated the default access control list of the data views collection.
 
 204-dataviews-owner-update:
   type: text/plain
   value: |
-    Successfully updated the data view owner
+    Successfully updated the data view owner.
 
 # Response Code: 302 Found
 302-data-get:
   type: markup
   value: |
-    The specified data view already exists. A response header, `Location`, indicates the URL where the data view may be retrieved with the `GET` verb
+    The specified data view already exists. A response header, `Location`, indicates the URL where the data view may be retrieved with the `GET` verb.
 
 # Response Code: 400 Bad Request
 400-data-get:
@@ -112,85 +112,85 @@
 400-standard-message:
   type: text/plain
   value: |
-    The request is not valid. See the response body for details
+    The request is not valid. See the response body for details.
 
 # Response Code: 403 Forbidden
 403-dataview-acl-get:
   type: text/plain
   value: |
-    You are not authorized to view the requested data view's access control list
+    You are not authorized to view the requested data view's access control list.
 
 403-dataview-acl-update:
   type: text/plain
   value: |
-    You are not authorized to update the requested data view's access control list
+    You are not authorized to update the requested data view's access control list.
 
 403-dataview-create:
   type: text/plain
   value: |
-    You are not authorized to create a data view
+    You are not authorized to create a data view.
 
 403-dataview-get:
   type: text/plain
   value: |
-    You are not authorized to view the requested data view
+    You are not authorized to view the requested data view.
 
 403-dataview-owner-get:
   type: text/plain
   value: |
-    You are not authorized to view the requested data view's owner
+    You are not authorized to view the requested data view's owner.
 
 403-dataview-owner-update:
   type: text/plain
   value: |
-    You are not authorized to update the requested data view's owner
+    You are not authorized to update the requested data view's owner.
 
 403-dataviews-accessrights-get:
   type: text/plain
   value: |
-    You are not authorized to view the requested data view collection's access control list
+    You are not authorized to view the requested data view collection's access control list.
 
 403-dataviews-acl-get:
   type: text/plain
   value: |
-    You are not authorized to view the requested data view collection's access control list
+    You are not authorized to view the requested data view collection's access control list.
 
 403-dataviews-acl-update:
   type: text/plain
   value: |
-    You are not authorized to update the data views collection's default access control list
+    You are not authorized to update the data views collection's default access control list.
 
 403-standard-message:
   type: text/plain
   value: |
-    You are not authorized for this operation
+    You are not authorized for this operation.
 
 # Response Code: 404 Not Found
 404-dataitems-get:
   type: text/plain
   value: |
-    The data view or query does not exist
+    The data view or query does not exist.
 
 404-dataview-standard-message:
   type: text/plain
   value: |
-    The requested data view was not found
+    The requested data view was not found.
 
 404-dataviewid-standard-message:
   type: text/plain
   value: |
-    The specified data view identifier is not found
+    The specified data view identifier is not found.
 
 404-fieldmappings-get:
   type: text/plain
   value: |
-    The data view or query does not exist
+    The data view or query does not exist.
 
 # Response Code: 409 Conflict
 409-data-get:
   type: text/plain
   value: |
-    The specified data view conflicts with an existing data view that is not identical. To forcibly update the data view, see *Create Or Update Data View*
+    The specified data view conflicts with an existing data view that is not identical. To forcibly update the data view, see *Create Or Update Data View*.
 
 # Response Code: 500 Internal Server Error
 500-standard-message:

--- a/content/external-references/dataviews-summaries.yaml
+++ b/content/external-references/dataviews-summaries.yaml
@@ -2,12 +2,12 @@
 class-collectionaccessrightscontroller:
   type: text/plain
   value: |
-    APIs for retrieving access rights on the data views collection
+    APIs for retrieving access rights on the data views collection.
 
 class-collectionaclcontroller:
   type: text/plain
   value: |
-    APIs for working with the Access Control List of the data view collection
+    APIs for working with the Access Control List of the data view collection.
 
 class-dataviewsdatacontroller:
   type: markdown
@@ -72,7 +72,7 @@ dataview-owner-update:
 dataviews-accessrights-get:
   type: text/plain
   value: |
-    Gets the access rights to the data views collection for the calling user or client
+    Gets the access rights to the data views collection for the calling user or client.
 
 dataviews-acl-get:
   type: markdown

--- a/content/external-references/parameters.yaml
+++ b/content/external-references/parameters.yaml
@@ -2,15 +2,15 @@
 namespaceId:
   type: text/plain
   value: |
-    Namespace identifier
+    Namespace identifier.
 tenantId:
   type: text/plain
   value: |
-    Tenant identifier
+    Tenant identifier.
 query:
   type: text/plain
   value: |
-    Query identifier
+    Query identifier.
 count:
   type: text/plain
   value: |
@@ -22,92 +22,92 @@ skip:
 key:
   type: text/plain
   value: |
-    Key specifying the metadata value of interest
+    Key specifying the metadata value of interest.
 cancellation-token:
   type: text/plain
   value: |
-    Cancellation token
+    Cancellation token.
 scheme:
   type: text/plain
   value: |
-    Scheme name (for example, AAD or Google)
+    Scheme name (for example, AAD or Google).
 # Community parameters
 tenantId-community:
   type: text/plain
   value: |
-    Owning tenant identifier
+    Owning tenant identifier.
 communityId:
   type: text/plain
   value: |
-    Community identifier
+    Community identifier.
 query-community:
   type: text/plain
   value: |
-    (Not supported) Query identifier
+    (Not supported) Query identifier.
 # Tenant identifier parameters for AAD when there are different types of tenants to have to consider and distinguish
 tenantId-OCS:
   type: text/plain
   value: |
-    OCS tenant identifier
+    OCS tenant identifier.
 tenantId-aad:
   type: text/plain
   value: |
-    Azure Active Directory tenant identifier
+    Azure Active Directory tenant identifier.
 groupId:
   type: text/plain
   value: |
-    Group identifier
+    Group identifier.
 clientId:
   type: text/plain
   value: |
-    Client identifier
+    Client identifier.
 streamId:
   type: text/plain
   value: |
-    Stream identifier
+    Stream identifier.
 # Identity provider focused identifiers
 identityProviderId:
   type: text/plain
   value: |
-    Identity provider identifier
+    Identity provider identifier.
 identityProviderClaimId:
   type: text/plain
   value: |
-    Identity provider claim identifier
+    Identity provider claim identifier.
 identityProviderTypeNameClaimId:
   type: text/plain
   value: |
-    Identity provider claim type name identifier
+    Identity provider claim type name identifier.
 # Other types of identifiers
 invitationId:
   type: text/plain
   value: |
-    Invitation identifier
+    Invitation identifier.
 userId:
   type: text/plain
   value: |
-    User identifier
+    User identifier.
 datasourceId:
   type: text/plain
   value: |
-    Data source identifier
+    Data source identifier.
 dataViewId:
   type: text/plain
   value: |
-    Data view identifier
+    Data view identifier.
 # OMF parameters
 subscriptionId:
   type: text/plain
   value: |
-    Subscription identifier
+    Subscription identifier.
 topicId:
   type: text/plain
   value: |
-    Topic identifier
+    Topic identifier.
 secretId:
   type: text/plain
   value: |
-    Secret identifier
+    Secret identifier.
 # Used for getting a list of identifiers in a GET method
 id:
   type: text/plain
@@ -116,9 +116,9 @@ id:
 tag:
   type: text/plain
   value: |
-    Only return clients that have these tags
+    Only return clients that have these tags.
 # Query for wildcard search 
 query-searchstring:
   type: text/plain
   value: |
-    (Not supported) Search string identifier
+    (Not supported) Search string identifier.

--- a/content/external-references/responses.yaml
+++ b/content/external-references/responses.yaml
@@ -1,40 +1,40 @@
 200:
   type: text/plain
   value: |
-    Success
+    Success.
 201:
   type: text/plain
   value: |
-    Created
+    Created.
 204:
   type: text/plain
   value: |
-    Deleted
+    Deleted.
 207:
   type: text/plain
   value: |
-    Partial 
+    Partial.
 400:
   type: text/plain
   value: |
-    Missing or invalid inputs
+    Missing or invalid inputs.
 401:
   type: text/plain
   value: |
-    Unauthorized
+    Unauthorized.
 403:
   type: text/plain
   value: |
-    Forbidden
+    Forbidden.
 404:
   type: text/plain
   value: |
-    Client or tenant not found
+    Client or tenant not found.
 408:
   type: text/plain
   value: |
-    Operation timed out
+    Operation timed out.
 500:
   type: text/plain
   value: |
-    Internal server error
+    Internal server error.

--- a/content/external-references/sds.yaml
+++ b/content/external-references/sds.yaml
@@ -1,23 +1,23 @@
 tenant:
   type: text/plain
   value: |
-    Tenant identifier
+    Tenant identifier.
 namespace:
   type: text/plain
   value: |
-    Namespace identifier
+    Namespace identifier.
 stream:
   type: text/plain
   value: |
-    Stream identifier
+    Stream identifier.
 type:
   type: text/plain
   value: |
-    Type identifier
+    Type identifier.
 view:
   type: text/plain
   value: |
-    Stream view identifier
+    Stream view identifier.
 count:
   type: text/plain
   value: |
@@ -42,19 +42,19 @@ query:
 filter:
   type: text/plain
   value: |
-    Filter expression
+    Filter expression.
 startindex:
   type: text/plain
   value: |
-    Index identifying the beginning of the series of events to return
+    Index identifying the beginning of the series of events to return.
 endindex:
   type: text/plain
   value: |
-    Index identifying the end of the series of events to return
+    Index identifying the end of the series of events to return.
 boundaryType:
   type: text/plain
   value: |
-    SdsBoundaryType specifying the handling of events at or near the start and end indexes
+    SdsBoundaryType specifying the handling of events at or near the start and end indexes.
 startBoundaryType:
   type: text/plain
   value: |


### PR DESCRIPTION
Per our discussions and agreements, I am adding a period (.) at the end of all parameter descriptions and response code descriptions in :

-common.yml
-parameters.yml
-responses.yml

In addition, I examined other yaml files in our \external-references repo for description sentences without a period, and added a period to them.