### PR TITLE
Asset Store TOC reorg

### DIFF
--- a/content/api-reference/assets/toc.yml
+++ b/content/api-reference/assets/toc.yml
@@ -1,14 +1,14 @@
+- name: Access control
+  href: assets-access-control-list.md
+- name: Asset types 
+  href: assets-asset-types.md
 - name: Assets
   href: assets-asset.md
-- name: Asset types 
-  href: assets-asset-type.md
-- name: Resolved asset
-  href: assets-resolved-asset.md
 - name: Assets data
   href: assets-asset-centric-data.md
-- name: Asset and asset type status
+- name: Asset status
   href: assets-asset-status.md
 - name: Assets search
   href: assets-search-asset.md
-- name: Asset and AssetType ACL
-  href: assets-access-control-list.md
+- name: Resolved assets
+  href: assets-resolved-asset.md

--- a/content/api-reference/assets/toc.yml
+++ b/content/api-reference/assets/toc.yml
@@ -3,12 +3,12 @@
 - name: Asset types 
   href: assets-asset-types.md
 - name: Assets
-  href: assets-asset.md
+  href: assets-assets.md
 - name: Assets data
   href: assets-asset-centric-data.md
 - name: Asset status
   href: assets-asset-status.md
 - name: Assets search
-  href: assets-search-asset.md
+  href: assets-assets-search.md
 - name: Resolved assets
   href: assets-resolved-asset.md

--- a/content/api-reference/assets/toc.yml
+++ b/content/api-reference/assets/toc.yml
@@ -1,14 +1,14 @@
 - name: Access control
   href: assets-access-control-list.md
-- name: Asset types 
-  href: assets-asset-types.md
 - name: Assets
   href: assets-assets.md
-- name: Assets data
+- name: Asset data
   href: assets-asset-centric-data.md
+- name: Asset search
+  href: assets-assets-search.md
 - name: Asset status
   href: assets-asset-status.md
-- name: Assets search
-  href: assets-assets-search.md
-- name: Resolved assets
+- name: Asset types 
+  href: assets-asset-types.md
+- name: Resolved asset
   href: assets-resolved-asset.md

--- a/content/api-reference/toc.yml
+++ b/content/api-reference/toc.yml
@@ -21,7 +21,7 @@
   topicHref: rules/rules-overview.md
 - name: Asset store
   href: assets/toc.yml
-  topicHref: Assets/assets.md 
+  topicHref: Assets/assets.md
 - name: Communities (Preview)
   href: community/toc.yml
   topicHref: community/community-overview.md

--- a/content/api-reference/toc.yml
+++ b/content/api-reference/toc.yml
@@ -21,8 +21,7 @@
   topicHref: rules/rules-overview.md
 - name: Asset store
   href: assets/toc.yml
-  # TODO: create this topic 
-  # topicHref: Assets/assets.md 
+  topicHref: Assets/assets.md 
 - name: Communities (Preview)
   href: community/toc.yml
   topicHref: community/community-overview.md

--- a/content/api-reference/toc.yml
+++ b/content/api-reference/toc.yml
@@ -21,7 +21,8 @@
   topicHref: rules/rules-overview.md
 - name: Asset store
   href: assets/toc.yml
-  topicHref: Assets/assets.md
+  # TODO: create this topic 
+  # topicHref: Assets/assets.md 
 - name: Communities (Preview)
   href: community/toc.yml
   topicHref: community/community-overview.md


### PR DESCRIPTION
* Alphabetized TOC for API Reference > Asset store.
* Retitled "Asset and AssetType ACL" to "Access control".
* Retitled "Asset and asset type status" to "Assets status"
* Fixed a couple typos.

[Output preview](https://osisoft-dev.zoominsoftware.io/bundle/ocs-docupipe-assets-toc-update/page/api-reference/assets/assets-access-control-list.html) 