### PR TITLE
Identity TOC Reorg

### DIFF
--- a/content/api-reference/identity/toc.yml
+++ b/content/api-reference/identity/toc.yml
@@ -20,9 +20,11 @@
   href: identity-invitations.md
 - name: Secrets
   href: identity-secrets.md
+- name: Role-based access control
+  topicUid: accessControl 
 - name: Tenants roles
   href: identity-tenants-roles.md
 - name: Users roles
   href: identity-users-roles.md
-- name: Tenants Users
+- name: Tenants users
   href: identity-tenants-users.md 

--- a/content/api-reference/toc.yml
+++ b/content/api-reference/toc.yml
@@ -25,8 +25,6 @@
 - name: Communities (Preview)
   href: community/toc.yml
   topicHref: community/community-overview.md
-- name: Role-based access control
-  topicHref: ../developer-guide/identity-dev/dev-guide-role-based-access-control.md
 - name: HTTP status codes
   topicHref: http-status-codes.md
 - name: Samples


### PR DESCRIPTION
* Moved "Role-based access control" from **API Reference > Role-based access control** to **API Reference > Identity and access management > Role-based access control**. 
*  Corrected a title typo.

[output preview](https://osisoft-dev.zoominsoftware.io/bundle/ocs-docupipe-identity-toc-update/page/developer-guide/identity-dev/dev-guide-role-based-access-control_1.html)