### PR TITLE
Vtouati pbi 273735 preview status

### DIFF
--- a/content/add-organize-data/collect-data/connectors/pi-to-ocs/main-lp.md
+++ b/content/add-organize-data/collect-data/connectors/pi-to-ocs/main-lp.md
@@ -4,7 +4,6 @@ uid: main-lp
 
 # PI to OCS (Preview)
 
-The fully released version of PI to OCS enables you to transfer on-prem PI data to OCS.  
+The fully released version of PI to OCS enables you to transfer your on-prem PI data to OCS.  
 
 **Note:** The preview version enables customers who are enrolled in the PI to OCS Lighthouse program to transfer both on-prem PI data and Asset Framework (AF) data to OCS. If you are interested in participating in the PI to OCS Lighthouse program, send an email to lighthouse@osisoft.com.
- 

--- a/content/add-organize-data/collect-data/connectors/pi-to-ocs/main-lp.md
+++ b/content/add-organize-data/collect-data/connectors/pi-to-ocs/main-lp.md
@@ -4,5 +4,7 @@ uid: main-lp
 
 # PI to OCS (Preview)
 
-The PI to OCS lighthouse release enables you to transfer both on-prem PI data and AF data to OCS. If you are interested in participating in the PI to OCS Lighthouse program, send an email to lighthouse@osisoft.com.
+The fully released version of PI to OCS enables you to transfer on-prem PI data to OCS.  
+
+**Note:** The preview version enables customers who are enrolled in the PI to OCS Lighthouse program to transfer both on-prem PI data and Asset Framework (AF) data to OCS. If you are interested in participating in the PI to OCS Lighthouse program, send an email to lighthouse@osisoft.com.
  

--- a/content/add-organize-data/collect-data/connectors/pi-to-ocs/main-lp.md
+++ b/content/add-organize-data/collect-data/connectors/pi-to-ocs/main-lp.md
@@ -6,4 +6,4 @@ uid: main-lp
 
 The fully released version of PI to OCS enables you to transfer your on-prem PI data to OCS.  
 
-**Note:** The preview version enables customers who are enrolled in the PI to OCS Lighthouse program to transfer both on-prem PI data and Asset Framework (AF) data to OCS. If you are interested in participating in the PI to OCS Lighthouse program, send an email to lighthouse@osisoft.com.
+**Note:** The preview version enables customers who are enrolled in the PI to OCS Lighthouse program to transfer both on-prem PI data and Asset Framework (AF) data to OCS. If you are interested in participating in the PI to OCS lighthouse program, send an email to lighthouse@osisoft.com.


### PR DESCRIPTION
Small addition to the main landing page for PI to OCS. Added first sentence in response to customer feedback/confusion about why "Preview" still appears in the TOC menu. Will also add this to the ADH version of the doc. Ironically, "Preview" will be removed in a few sprints.