### PR TITLE
Update description of event limit for read calls

### DIFF
--- a/content/developer-guide/sequential-data-store-dev/sds-read-data.md
+++ b/content/developer-guide/sequential-data-store-dev/sds-read-data.md
@@ -17,7 +17,7 @@ While SDS is a robust data storage, it performs best if you follow certain guide
 ### Maximum limit for events in read data calls 
 
 Read data API is limited to access fewer than 250,000 events per request.
-This includes events that are accessed but not returned, such as events that are being filtered out of the response.
+This limit includes events that are accessed but not returned, such as events that are being filtered out of the response.
 An error message is returned when the maximum limit is reached.  
 This maximum limit applies to [List Values](xref:sds-stream-data#list-values), [List Summaries](xref:sds-stream-data#list-summaries), [List Sampled Values](xref:sds-stream-data#list-sampled-values).
  

--- a/content/developer-guide/sequential-data-store-dev/sds-read-data.md
+++ b/content/developer-guide/sequential-data-store-dev/sds-read-data.md
@@ -16,7 +16,8 @@ While SDS is a robust data storage, it performs best if you follow certain guide
 
 ### Maximum limit for events in read data calls 
 
-Read data API is limited to retrieve less than 250,000 events per request.
+Read data API is limited to access less than 250,000 events per request.
+This includes events that are accessed but not returned, such as events that are being filtered out of the response.
 An error message is returned when the maximum limit is reached.  
 This maximum limit applies to [List Values](xref:sds-stream-data#list-values), [List Summaries](xref:sds-stream-data#list-summaries), [List Sampled Values](xref:sds-stream-data#list-sampled-values).
  

--- a/content/developer-guide/sequential-data-store-dev/sds-read-data.md
+++ b/content/developer-guide/sequential-data-store-dev/sds-read-data.md
@@ -16,7 +16,7 @@ While SDS is a robust data storage, it performs best if you follow certain guide
 
 ### Maximum limit for events in read data calls 
 
-Read data API is limited to access less than 250,000 events per request.
+Read data API is limited to access fewer than 250,000 events per request.
 This includes events that are accessed but not returned, such as events that are being filtered out of the response.
 An error message is returned when the maximum limit is reached.  
 This maximum limit applies to [List Values](xref:sds-stream-data#list-values), [List Summaries](xref:sds-stream-data#list-summaries), [List Sampled Values](xref:sds-stream-data#list-sampled-values).


### PR DESCRIPTION
Behavior of the maximum read count setting has changed from setting a constraint on the number of events returned during a read data call, to the number of events accessed.