### PR TITLE
366220 correct incorrect information in search documentation and add more examples

### DIFF
--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -47,7 +47,7 @@ Stream metadata keys are only searchable in association with their values. Witho
 
 ## Special characters in search queries
 
-Add the backslash escape character ( \ ) before any special characters in search queries. The following special characters require an escape character: " | / * \ ( ) :
+Add the backslash escape character ( \ ) before any special characters in search queries. The following special characters require an escape character: " | / * \ ( ) : 
 
 The following are examples of using the escape character in query strings.
 
@@ -55,7 +55,7 @@ The following are examples of using the escape character in query strings.
 | -------------------------------------- | ------------------------------------------ |
 | Austin\Dallas\Fort Worth               | Austin\\\Dallas\\\Fort Worth               |
 | 1:100                                  | 1\\:100                                    |
-| http://www.aveva.com                   | http\\:\\/\\/www.aveva.com                 |
+| http://www.aveva.com                   | http\\:\\/\\/www.aveva.com                 | 
 
 ## Examples of query strings
 

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -4,7 +4,7 @@ uid: Search
 
 # Search in OCS
 
-Many pages in OSIsoft (OCS) include a search capability, including:
+Many pages in OSIsoft Cloud Services (OCS) include a search capability, including:
 
 - Sequential Data Store (streams, types, stream views)
 - Asset Explorer (assets, asset types)

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -4,7 +4,7 @@ uid: Search
 
 # Search in OCS
 
-Many pages in OSIsoftOCS include a search capability, including:
+Many pages in OSIsoft (OCS) include a search capability, including:
 
 - Sequential Data Store (streams, types, stream views)
 - Asset Explorer (assets, asset types)

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -66,8 +66,7 @@ The following are examples of using the escape character in query strings.
 | Name:Name1 | assets, streams, stream types, stream views | Returns all items with a name equal to **Name1**. |
 | Id:Id AND Name:Name1 | assets, streams, stream types, stream views | Returns the item with an Id equal to **Id** and a name equal to **Name1**. |
 | Description:floor1* | assets, streams, stream types, stream views | Returns all items with a description that starts with **floor1**. |
-| Metadata/Name:\*building* | assets, streams | Returns all items with at least one metadata name that contains the string **building**. |
-| Metadata/Value:123 | assets, streams | Returns all items with at least one metadata whose value equals **123**. |
+| Metadata/Serial Number:M0000* | assets, streams | Return all items that include metadata of the name "Serial Number" that start with **M0000** (such as M000099 and M000001). |
 | Id:X* AND Metadata/Location:B* | assets, streams | Returns all items that contains: <ul><li>An Id starting with **X**.</li><li>A metadata with the name <code>Location</code> that has a value that starts with <code>B</code> (such as "Boston").</li></ul> |
 | Tags:MarkedAsset | assets, streams | Returns all items that have **MarkedAsset** as a tag. |
 | AssetTypeId:HeaterTypeId | assets | Returns all items with AssetTypeId matching **HeaterTypeId**. |

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -2,7 +2,7 @@
 uid: Search
 ---
 
-# Search query options in OCS
+# Search
 
 Many pages in OCS include a search capability, including:
 
@@ -24,11 +24,11 @@ You can use search operators to get more refined search results. Use the operato
 | ``AND``  | AND operator. The query ``cat AND dog`` searches for both "cat" and "dog". |
 | ``OR``   | OR operator. The query ``cat OR dog`` searches for either "cat" or "dog", or both. |
 | ``NOT``  | NOT operator. The query ``cat NOT dog`` searches for "cat" or those without "dog". |
-| ``*``    | Wildcard operator. Matches 0 or more characters. See [Wildcard operator](#wildcard). |
-| ``:``    | Field-scoped query. Specifies a field to search. See [Field-scoping operator](#fieldScoped). |
+| ``*``    | Wildcard operator. Matches 0 or more characters. See [Wildcard operator](#wildcard--operator). |
+| ``:``    | Field-scoped query. Specifies a field to search. See [Field-scoping operator](#field-scoping--operator). |
 | ``( )``  | Precedence operator. The query ``wind AND (speed OR deviation)`` searches for either "wind" and "speed", or "wind" and "deviation". |
 
-## <a name="wildcard"></a>Wildcard (``*``) operator
+## Wildcard (``*``) operator
 
 Searching for a value finds only exact, whole-word matches. As an example, searching for "temperature" will not match a field value of "temperatures". You can use the wildcard operator (``*``) to match a partial search term. The wildcard can be used in the front (``*``perature), middle (tem``*``rature), or at the end (temp``*``) of each search term. It can only be used once for each search term, except to enclose a term (``*``perat``*``). OCS does not support wildcard operators in the middle and at the front or end of a term (te``*``pera``*`` is invalid).
 
@@ -39,7 +39,7 @@ Searching for a value finds only exact, whole-word matches. As an example, searc
 | ``*log*``        | analog<br>alogger       | lop                            |
 | ``l*g``          | log<br>logg             | lake swimming (``*`` does not span across tokens) |
 
-## <a name="fieldScoped"></a>Field-scoping (``:``) operator
+## Field-scoping (``:``) operator
 
 The field-scoping operator limits the search to a specific field, such as ``id:``, ``name:``, ``description:``, and ``metadatakey:``.
 

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -24,11 +24,11 @@ You can use search operators to get more refined search results. Use the operato
 | ``AND``  | AND operator. The query ``cat AND dog`` searches for both "cat" and "dog". |
 | ``OR``   | OR operator. The query ``cat OR dog`` searches for either "cat" or "dog", or both. |
 | ``NOT``  | NOT operator. The query ``cat NOT dog`` searches for "cat" or those without "dog". |
-| ``*``    | Wildcard operator. Matches 0 or more characters. See [Wildcard operator](#wildcard--operator). |
-| ``:``    | Field-scoped query. Specifies a field to search. See [Field-scoping operator](#field-scoping--operator). |
+| ``*``    | Wildcard operator. Matches 0 or more characters. See [Wildcard operator](#wildcard). |
+| ``:``    | Field-scoped query. Specifies a field to search. See [Field-scoping operator](#fieldScoped). |
 | ``( )``  | Precedence operator. The query ``wind AND (speed OR deviation)`` searches for either "wind" and "speed", or "wind" and "deviation". |
 
-## Wildcard (``*``) operator
+## <a name="wildcard"></a>Wildcard (``*``) operator
 
 Searching for a value finds only exact, whole-word matches. As an example, searching for "temperature" will not match a field value of "temperatures". You can use the wildcard operator (``*``) to match a partial search term. The wildcard can be used in the front (``*``perature), middle (tem``*``rature), or at the end (temp``*``) of each search term. It can only be used once for each search term, except to enclose a term (``*``perat``*``). OCS does not support wildcard operators in the middle and at the front or end of a term (te``*``pera``*`` is invalid).
 
@@ -39,7 +39,7 @@ Searching for a value finds only exact, whole-word matches. As an example, searc
 | ``*log*``        | analog<br>alogger       | lop                            |
 | ``l*g``          | log<br>logg             | lake swimming (``*`` does not span across tokens) |
 
-## Field-scoping (``:``) operator
+## <a name="fieldScoped"></a>Field-scoping (``:``) operator
 
 The field-scoping operator limits the search to a specific field, such as ``id:``, ``name:``, ``description:``, and ``metadatakey:``.
 

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -1,11 +1,10 @@
 ---
 uid: Search
-title: "Search", "search"
 ---
 
-# Search
+# Search in OCS
 
-Many pages in OCS include a search capability, including:
+Many pages in OSIsoftOCS include a search capability, including:
 
 - Sequential Data Store (streams, types, stream views)
 - Asset Explorer (assets, asset types)
@@ -31,7 +30,7 @@ You can use search operators to get more refined search results. Use the operato
 
 ## Wildcard (``*``) operator
 
--Searching for a value finds only exact, whole-word matches. As an example, searching for "temperature" will not match a field value of "temperatures". You can use the wildcard operator (``*``) to match a partial search term. The wildcard can be //*+used in the front (``*``perature), middle (tem``*``rature), or at the end (temp``*``) of each search term. It can only be used once for each search term, except to enclose a term (``*``perat``*``). OCS does not support wildcard operators in the middle and at the front or end of a term (te``*``pera``*`` is invalid).
+Searching for a value finds only exact, whole-word matches. As an example, searching for "temperature" will not match a field value of "temperatures". You can use the wildcard operator (``*``) to match a partial search term. The wildcard can be used in the front (``*``perature), middle (tem``*``rature), or at the end (temp``*``) of each search term. It can only be used once for each search term, except to enclose a term (``*``perat``*``). OCS does not support wildcard operators in the middle and at the front or end of a term (te``*``pera``*`` is invalid).
 
 | **Query string** | **Matches field value** | **Does not match field value** |
 | ---------------- | ----------------------- | ------------------------------ |
@@ -48,7 +47,7 @@ Stream metadata keys are only searchable in association with their values. Witho
 
 ## Special characters in search queries
 
-Add the backslash escape character ( \ ) before any special characters in search queries. The following special characters require an escape character: " | / * \ ( ) : 
+Add the backslash escape character ( \ ) before any special characters in search queries. The following special characters require an escape character: " | / * \ ( ) :
 
 The following are examples of using the escape character in query strings.
 
@@ -56,7 +55,7 @@ The following are examples of using the escape character in query strings.
 | -------------------------------------- | ------------------------------------------ |
 | Austin\Dallas\Fort Worth               | Austin\\\Dallas\\\Fort Worth               |
 | 1:100                                  | 1\\:100                                    |
-| http://www.aveva.com                   | http\\:\\/\\/www.aveva.com                 | 
+| http://www.aveva.com                   | http\\:\\/\\/www.aveva.com                 |
 
 ## Examples of query strings
 
@@ -69,6 +68,29 @@ The following are examples of using the escape character in query strings.
 | Description:floor1*          | assets, streams, stream types, stream views | Returns all items with a description that starts with **floor1**. |
 | Metadata/Name:\*building*    | assets, streams                             | Returns all items with at least one metadata name that contains the string **building**. |
 | Metadata/Value:123           | assets, streams                             | Returns all items with at least one metadata whose value equals **123**. |
-| Id:X* AND Metadata/Name:"B"*   | assets, streams                             | Returns all items with an Id starting with **X** and containing at least one metada0025196
+| Id:X* AND Metadata/Name:B*   | assets, streams                             | Returns all items with an Id starting with **X** and containing at least one metadata value that starts with **B** within a phrase. |
+| Id:X* AND Metadata/Name:"B"* | assets, streams                             | Returns all items with an Id starting with **X** and containing at least one metadata value with a name that starts with **B**. |
+| Tags:MarkedAsset             | assets, streams                             | Returns all items that have **MarkedAsset** as a tag. |
+| AssetTypeId:HeaterTypeId     | assets                                      | Returns all items with AssetTypeId matching **HeaterTypeId**. |
+| AssetTypeName:HeaterTypeName | assets                                      | Returns all items whose asset type Name field matches **HeaterTypeName**. |
+| StreamPropertyId:Pressure    | assets                                      | Returns all items that have one or more stream references with the stream property ID **Pressure**. Note: This search only searches non-key Sds stream properties. |
+| StreamReferenceName:Name1    | assets                                      | Returns all items whose stream references contain a stream reference name that matches **Name1**. |
 
+## Search result examples
 
+When searching for the following streams:
+
+**streamId** | **Name**  | **Description**
+------------ | --------- | ----------------
+stream1      | tempA     | Temperature from DeviceA
+stream2      | pressureA | Pressure from DeviceA
+stream3      | calcA     | Calculation from DeviceA values
+
+Entering the following queries returns the following streams:
+
+**Query string**     | **Returns**
+------------------  | ----------------------------------------
+``temperature``  | stream1
+``calc*``        | stream3
+``DeviceA*``     | stream1, stream2, stream3
+``humidity*``    | nothing

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -59,22 +59,21 @@ The following are examples of using the escape character in query strings.
 
 ## Examples of query strings
 
-| Query String                 | Applies to                                  | Description                                       |
-| ---------------------------- | ------------------------------------------- | ------------------------------------------------- |
-| Id:Id1                       | assets, streams, stream types, stream views | Returns the item whose Id is **Id1**. |
-| Id:Id*                       | assets, streams, stream types, stream views | Returns all items with Ids that begin with **Id**. |
-| Name:Name1                   | assets, streams, stream types, stream views | Returns all items with a name equal to **Name1**. |
-| Id:Id AND Name:Name1         | assets, streams, stream types, stream views | Returns the item with an Id equal to **Id** and a name equal to **Name1**. |
-| Description:floor1*          | assets, streams, stream types, stream views | Returns all items with a description that starts with **floor1**. |
-| Metadata/Name:\*building*    | assets, streams                             | Returns all items with at least one metadata name that contains the string **building**. |
-| Metadata/Value:123           | assets, streams                             | Returns all items with at least one metadata whose value equals **123**. |
-| Id:X* AND Metadata/Name:B*   | assets, streams                             | Returns all items with an Id starting with **X** and containing at least one metadata value that starts with **B** within a phrase. |
-| Id:X* AND Metadata/Name:"B"* | assets, streams                             | Returns all items with an Id starting with **X** and containing at least one metadata value with a name that starts with **B**. |
-| Tags:MarkedAsset             | assets, streams                             | Returns all items that have **MarkedAsset** as a tag. |
-| AssetTypeId:HeaterTypeId     | assets                                      | Returns all items with AssetTypeId matching **HeaterTypeId**. |
-| AssetTypeName:HeaterTypeName | assets                                      | Returns all items whose asset type Name field matches **HeaterTypeName**. |
-| StreamPropertyId:Pressure    | assets                                      | Returns all items that have one or more stream references with the stream property ID **Pressure**. Note: This search only searches non-key Sds stream properties. |
-| StreamReferenceName:Name1    | assets                                      | Returns all items whose stream references contain a stream reference name that matches **Name1**. |
+| Query String | Applies to | Description |
+|---|---|---|
+| Id:Id1 | assets, streams, stream types, stream views | Returns the item whose Id is **Id1**. |
+| Id:Id* | assets, streams, stream types, stream views | Returns all items with Ids that begin with **Id**. |
+| Name:Name1 | assets, streams, stream types, stream views | Returns all items with a name equal to **Name1**. |
+| Id:Id AND Name:Name1 | assets, streams, stream types, stream views | Returns the item with an Id equal to **Id** and a name equal to **Name1**. |
+| Description:floor1* | assets, streams, stream types, stream views | Returns all items with a description that starts with **floor1**. |
+| Metadata/Name:\*building* | assets, streams | Returns all items with at least one metadata name that contains the string **building**. |
+| Metadata/Value:123 | assets, streams | Returns all items with at least one metadata whose value equals **123**. |
+| Id:X* AND Metadata/Location:B* | assets, streams | Returns all items that contains: <ul><li>An Id starting with **X**.</li><li>A metadata with the name <code>Location</code> that has a value that starts with <code>B</code> (such as "Boston").</li></ul> |
+| Tags:MarkedAsset | assets, streams | Returns all items that have **MarkedAsset** as a tag. |
+| AssetTypeId:HeaterTypeId | assets | Returns all items with AssetTypeId matching **HeaterTypeId**. |
+| AssetTypeName:HeaterTypeName | assets | Returns all items whose asset type Name field matches **HeaterTypeName**. |
+| StreamPropertyId:Pressure | assets | Returns all items that have one or more stream references with the stream property ID **Pressure**. Note: This search only searches non-key Sds stream properties. |
+| StreamReferenceName:Name1 | assets | Returns all items whose stream references contain a stream reference name that matches **Name1**. |
 
 ## Search result examples
 

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -1,5 +1,6 @@
 ---
 uid: Search
+title: "Search", "search"
 ---
 
 # Search
@@ -30,7 +31,7 @@ You can use search operators to get more refined search results. Use the operato
 
 ## Wildcard (``*``) operator
 
-Searching for a value finds only exact, whole-word matches. As an example, searching for "temperature" will not match a field value of "temperatures". You can use the wildcard operator (``*``) to match a partial search term. The wildcard can be used in the front (``*``perature), middle (tem``*``rature), or at the end (temp``*``) of each search term. It can only be used once for each search term, except to enclose a term (``*``perat``*``). OCS does not support wildcard operators in the middle and at the front or end of a term (te``*``pera``*`` is invalid).
+-Searching for a value finds only exact, whole-word matches. As an example, searching for "temperature" will not match a field value of "temperatures". You can use the wildcard operator (``*``) to match a partial search term. The wildcard can be //*+used in the front (``*``perature), middle (tem``*``rature), or at the end (temp``*``) of each search term. It can only be used once for each search term, except to enclose a term (``*``perat``*``). OCS does not support wildcard operators in the middle and at the front or end of a term (te``*``pera``*`` is invalid).
 
 | **Query string** | **Matches field value** | **Does not match field value** |
 | ---------------- | ----------------------- | ------------------------------ |
@@ -68,9 +69,6 @@ The following are examples of using the escape character in query strings.
 | Description:floor1*          | assets, streams, stream types, stream views | Returns all items with a description that starts with **floor1**. |
 | Metadata/Name:\*building*    | assets, streams                             | Returns all items with at least one metadata name that contains the string **building**. |
 | Metadata/Value:123           | assets, streams                             | Returns all items with at least one metadata whose value equals **123**. |
-| Id:X* AND Metadata/Name:B*   | assets, streams                             | Returns all items with an Id starting with **X** and containing at least one metadata value with a name that starts with **B**. |
-| Tags:MarkedAsset             | assets, streams                             | Returns all items that have **MarkedAsset** as a tag. |
-| AssetTypeId:HeaterTypeId     | assets                                      | Returns all items with AssetTypeId matching **HeaterTypeId**. |
-| AssetTypeName:HeaterTypeName | assets                                      | Returns all items whose asset type Name field matches **HeaterTypeName**. |
-| StreamPropertyId:Pressure    | assets                                      | Returns all items that have one or more stream references with the stream property ID **Pressure**. Note: This search only searches non-key Sds stream properties. |
-| StreamReferenceName:Name1    | assets                                      | Returns all items whose stream references contain a stream reference name that matches **Name1**. |
+| Id:X* AND Metadata/Name:"B"*   | assets, streams                             | Returns all items with an Id starting with **X** and containing at least one metada0025196
+
+

--- a/content/overview/search.md
+++ b/content/overview/search.md
@@ -4,7 +4,7 @@ uid: Search
 
 # Search in OCS
 
-Many pages in OSIsoft Cloud Services (OCS) include a search capability, including:
+Many pages in OCS include a search capability, including:
 
 - Sequential Data Store (streams, types, stream views)
 - Asset Explorer (assets, asset types)


### PR DESCRIPTION
Hi @RealVictorZhang ,

I made the changes that we discussed during our call yesterday. I made the following changes:

- Updated the title. The title change jumps this topic to the top of the search results for "search". You can confirm them [here](https://osisoft-dev.zoominsoftware.io/bundle/ocs-366220-merge-two-search-topics/page/ocs-content-portal-overview.html).
- Updated the existing example to accurately describe a tokenized search for "Id:X* AND Metadata/Name:B*"
- Added a new example for "Id:X* AND Metadata/Name:"B"*", which will give the user who raised the ticket the result they were expecting.
- Added the search example from "SDS Search" in the developer documentation.

